### PR TITLE
Add retry and delay properties to support setup cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Role Variables
 | dr_target_host          | primary               | Specify the default target host to be used in the ansible play.<br/> This hos indicates the target site which the recover process will bedone.      |
 | dr_source_map           | secondary             | Specify the default source map to be used in the play.</br/> The source map indicates the key which is used to get the target value for each attribute which we want to register with the VM/Template.       |
 | dr_reset_mac_pool       | True                  | If true, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
+| dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenace VM as part of a fail back scenario.       |
+| dr_cleanup_delay_maintenance       | 120                  | Specify the number of seconds between each retry as part of a fail back scenario.       |
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,9 @@ dr_source_map: "secondary"
 
 # Indicate whether to reset a mac pool of a VM on register.
 dr_reset_mac_pool: "True"
+
+# Indicate the number of retries of moving a storage domain to maintenance (In case of a failure because of running tasks).
+dr_cleanup_retries_maintenance: 3
+
+# Indicate the number of seconds between each maintenance retry (In case of a failure because of running tasks).
+dr_cleanup_delay_maintenance: 120

--- a/tasks/clean/remove_domain.yml
+++ b/tasks/clean/remove_domain.yml
@@ -9,3 +9,7 @@
       host: "{{ host }}"
       destroy: "{{ dr_force }}"
       data_center: "{{ sp_uuid }}"
+  register: result
+  until: not result|failed
+  retries: "{{ dr_cleanup_retries_maintenance }}"
+  delay: "{{ dr_cleanup_delay_maintenance }}"


### PR DESCRIPTION
On a DR cleanup scenario all storage domains are moved to maintenance
and detached from the DC.
Part of those storage domains might run tasks and could not be moved to
maintenance.
In that case the clean process should wait and try to move the SD to
maintenance after a delay.
To overcome that usecase two default attributes were added to configure
the retry and delay properties to support the cleanup.

Bug-Url: https://bugzilla.redhat.com/1533427