### PR TITLE
port additional properties patch from ansible to DR

### DIFF
--- a/library/ovirt_storage_domains.py
+++ b/library/ovirt_storage_domains.py
@@ -115,6 +115,22 @@ options:
             - "C(port) - Port of the fibre channel storage server."
             - "C(lun_id) - LUN id."
             - "Note that these parameters are not idempotent."
+    wipe_after_delete:
+        description:
+            - "Boolean flag which indicates whether the storage domain should wipe the data after delete."
+        version_added: "2.5"
+    backup:
+        description:
+            - "Boolean flag which indicates whether the storage domain is configured as backup or not."
+        version_added: "2.5"
+    critical_space_action_blocker:
+        description:
+            - "Inidcates the minimal free space the storage domain should contain in percentages."
+        version_added: "2.5"
+    warning_low_space:
+        description:
+            - "Inidcates the minimum percentage of a free space in a storage domain to present a warning."
+        version_added: "2.5"
     destroy:
         description:
             - "Logical remove of the storage domain. If I(true) retains the storage domain's data for import."
@@ -174,6 +190,10 @@ EXAMPLES = '''
        - 1IET_000d0001
        - 1IET_000d0002
       address: 10.34.63.204
+    discard_after_delete: True
+    backup: False
+    critical_space_action_blocker: 5
+    warning_low_space: 10
 
 # Add data glusterfs storage domain
 -  ovirt_storage_domains:
@@ -193,6 +213,10 @@ EXAMPLES = '''
     nfs:
       address: 10.34.63.199
       path: /path/export
+    wipe_after_delete: False
+    backup: True
+    critical_space_action_blocker: 2
+    warning_low_space: 5
 
 # Import export NFS storage domain:
 - ovirt_storage_domains:
@@ -299,6 +323,10 @@ class StorageDomainModule(BaseModule):
             name=self._module.params['name'],
             description=self._module.params['description'],
             comment=self._module.params['comment'],
+            wipe_after_delete=self._module.params['wipe_after_delete'],
+            backup=self._module.params['backup'],
+            critical_space_action_blocker=self._module.params['critical_space_action_blocker'],
+            warning_low_space_indicator=self._module.params['warning_low_space'],
             import_=(
                 True
                 if self._module.params['state'] == 'imported' else None
@@ -545,6 +573,10 @@ def main():
         posixfs=dict(default=None, type='dict'),
         glusterfs=dict(default=None, type='dict'),
         fcp=dict(default=None, type='dict'),
+        wipe_after_delete=dict(type='bool', default=None),
+        backup=dict(type='bool', default=None),
+        critical_space_action_blocker=dict(type='int', default=None),
+        warning_low_space=dict(type='int', default=None),
         destroy=dict(type='bool', default=False),
         format=dict(type='bool', default=False),
         discard_after_delete=dict(type='bool', default=True)


### PR DESCRIPTION
Port recent changes from https://github.com/ansible/ansible/pull/34904:

Add missing storage domain properties:

Add additional attributes on adding/import storage domain to oVirt.
The properties are :
wipe_after_delete - Boolean flag which indicates whether the storage domain should wipe the data after delete.
backup - Boolean flag which indicates whether the storage domain is configured as backup or not.
critical_space_action_blocker - Indicates what is the minimum free space the storage domain should contain.
warning_low_space - Indicates the minimum percentage of a free space in a storage domain to present a warning.