### PR TITLE
Add a proper error message when no hosts available

### DIFF
--- a/tasks/recover/add_domain.yml
+++ b/tasks/recover/add_domain.yml
@@ -1,38 +1,43 @@
 - ovirt_hosts_facts:
       pattern: "status=up and datacenter={{ storage['dr_' + dr_target_host + '_dc_name'] }}"
       auth: "{{ ovirt_auth }}"
+- block:
+  - name: "Check for available hosts"
+    fail: msg="No hosts available"
+    when: ovirt_hosts.0 is undefined
+- block:
+  - include_tasks: tasks/recover/add_nfs_domain.yml
+    with_items:
+      - "{{ storage }}"
+    when: "storage.dr_domain_type == 'nfs'"
+    loop_control:
+        loop_var: nfs_storage
 
-- include_tasks: tasks/recover/add_nfs_domain.yml
-  with_items:
-    - "{{ storage }}"
-  when: "storage.dr_domain_type == 'nfs'"
-  loop_control:
-      loop_var: nfs_storage
+  - include_tasks: tasks/recover/add_glusterfs_domain.yml
+    with_items:
+      - "{{ storage }}"
+    when: "storage.dr_domain_type == 'gluster'"
+    loop_control:
+        loop_var: gluster_storage
 
-- include_tasks: tasks/recover/add_glusterfs_domain.yml
-  with_items:
-    - "{{ storage }}"
-  when: "storage.dr_domain_type == 'gluster'"
-  loop_control:
-      loop_var: gluster_storage
+  - include_tasks: tasks/recover/add_posixfs_domain.yml
+    with_items:
+      - "{{ storage }}"
+    when: "storage.dr_domain_type == 'posixfs'"
+    loop_control:
+        loop_var: posix_storage
 
-- include_tasks: tasks/recover/add_posixfs_domain.yml
-  with_items:
-    - "{{ storage }}"
-  when: "storage.dr_domain_type == 'posixfs'"
-  loop_control:
-      loop_var: posix_storage
+  - include_tasks: tasks/recover/add_iscsi_domain.yml
+    with_items:
+      - "{{ storage }}"
+    when: "storage.dr_domain_type == 'iscsi'"
+    loop_control:
+        loop_var: iscsi_storage
 
-- include_tasks: tasks/recover/add_iscsi_domain.yml
-  with_items:
-    - "{{ storage }}"
-  when: "storage.dr_domain_type == 'iscsi'"
-  loop_control:
-      loop_var: iscsi_storage
-
-- include_tasks: tasks/recover/add_fcp_domain.yml
-  with_items:
-    - "{{ storage }}"
-  when: "storage.dr_domain_type == 'fcp'"
-  loop_control:
-      loop_var: fcp_storage
+  - include_tasks: tasks/recover/add_fcp_domain.yml
+    with_items:
+      - "{{ storage }}"
+    when: "storage.dr_domain_type == 'fcp'"
+    loop_control:
+        loop_var: fcp_storage
+  when: ovirt_hosts.0 is defined


### PR DESCRIPTION
This patch adds a proper error message when no hosts
are available instead of the "list object has no element 0"
message and stop the importing of storage domains for the
DC.

Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>