### PR TITLE
BZ1533385 - Add the ability to clean only mapped storage domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Role Variables
 | dr_reset_mac_pool       | True                  | If true, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
 | dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenace VM as part of a fail back scenario.       |
 | dr_cleanup_delay_maintenance       | 120                  | Specify the number of seconds between each retry as part of a fail back scenario.       |
+| dr_clean_orphaned_vms:       | True                  | Specify whether to remove any VMs which have no disks from the setup as part of cleanup.       |
+| dr_clean_orphaned_disks:       | True                  | Specify whether to remove lun disks from the setup as part of engine setup.       |
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,9 @@ dr_cleanup_retries_maintenance: 3
 
 # Indicate the number of seconds between each maintenance retry (In case of a failure because of running tasks).
 dr_cleanup_delay_maintenance: 120
+
+# Indicate whether to remove any VMs which have no disks from the setup as part of cleanup.
+dr_clean_orphaned_vms: "True"
+
+# Indicate whether to remove lun disks from the setup as part of engine setup.
+dr_clean_orphaned_disks: "True"

--- a/tasks/clean/remove_domain.yml
+++ b/tasks/clean/remove_domain.yml
@@ -3,13 +3,13 @@
 - name: Remove storage domain
   ovirt_storage_domains:
       state: absent
-      id: "{{ storage.id }}"
-      name: "{{ storage.name }}"
+      id: "{{ sd.id }}"
+      name: "{{ sd.name }}"
       auth: "{{ ovirt_auth }}"
       host: "{{ host }}"
       destroy: "{{ dr_force }}"
       data_center: "{{ sp_uuid }}"
   register: result
-  until: not result|failed
+  until: dr_force or result is not failed
   retries: "{{ dr_cleanup_retries_maintenance }}"
   delay: "{{ dr_cleanup_delay_maintenance }}"

--- a/tasks/clean/remove_domain_process.yml
+++ b/tasks/clean/remove_domain_process.yml
@@ -8,24 +8,24 @@
 
 - name: Detached storage domain - Set sp_uuid with empty GUID
   set_fact: sp_uuid="00000000-0000-0000-0000-000000000000"
-  when: storage.data_centers is not defined
+  when: sd.data_centers is not defined
 
 - name: Detached storage domain - Fetch active host for remove
   ovirt_hosts_facts:
     pattern: "status=up"
     auth: "{{ ovirt_auth }}"
-  when: storage.data_centers is not defined
+  when: sd.data_centers is not defined
 
 - name: Attached storage domain - Fetch active host for remove
   ovirt_hosts_facts:
-    pattern: "status=up and storage={{ storage.name }}"
+    pattern: "status=up and storage={{ sd.name }}"
     auth: "{{ ovirt_auth }}"
-  when: storage.data_centers is defined
+  when: sd.data_centers is defined
 
 # If sp_uuid is still initiated with the default boolean value,
 # that means that there is a data center which the storage domain is attached to it.
 - name: Attached storage domain - Set sp_uuid
-  set_fact: sp_uuid="{{ storage.data_centers[0].id }}"
+  set_fact: sp_uuid="{{ sd.data_centers[0].id }}"
   when: sp_uuid
 
 - name: Remove storage domain with no force
@@ -34,6 +34,5 @@
 
 - name: Force remove storage domain
   include_tasks: tasks/clean/remove_domain.yml host="00000000-0000-0000-0000-000000000000"
-  #storage={{ storage }} host={{ ovirt_hosts[0] }} sp_uuid=sp_uuid
-  when: "force"
+  when: "dr_force"
 

--- a/tasks/clean/remove_filtered_master_domains.yml
+++ b/tasks/clean/remove_filtered_master_domains.yml
@@ -1,0 +1,12 @@
+- name: Fetch storage domains for detach
+  ovirt_storage_domains_facts:
+      pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_query_domain_search }}
+      auth: "{{ ovirt_auth }}"
+
+- include_tasks: tasks/clean/remove_domain_process.yml sd={{ item }}
+  with_items:
+      - "{{ ovirt_storage_domains }}"
+  when: (not only_master and not sd.master) or (only_master and sd.master)
+  loop_control:
+      loop_var: sd
+

--- a/tasks/clean/shutdown_vm.yml
+++ b/tasks/clean/shutdown_vm.yml
@@ -1,0 +1,8 @@
+- name: Shutdown VMs
+  ovirt_vms:
+      state: stopped
+      name: "{{ vms.name }}"
+      force: True
+      wait: True
+      auth: "{{ ovirt_auth }}"
+

--- a/tasks/clean/shutdown_vms.yml
+++ b/tasks/clean/shutdown_vms.yml
@@ -1,8 +1,9 @@
-- name: Shutdown VMs
-  ovirt_vms:
-      state: stopped
-      name: "{{ vms.name }}"
-      force: True
-      wait: False
+# Get all the running VMs related to a storage domain and shut them down
+- name: Fetch VMs in the storage domain
+  ovirt_vms_facts:
+      pattern:  status != down and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}
       auth: "{{ ovirt_auth }}"
 
+# TODO: Add a wait until the VM is really down
+- include_tasks: tasks/clean/shutdown_vm.yml vms={{ item }}
+  with_items: "{{ ovirt_vms }}"

--- a/tasks/clean/update_ovf_store.yml
+++ b/tasks/clean/update_ovf_store.yml
@@ -1,5 +1,13 @@
-- name: update OVF store for storage domain
+- name: fetch storage domain only if active
+  ovirt_storage_domains_facts:
+      pattern:  status = active and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}
+      auth: "{{ ovirt_auth }}"
+
+- name: update OVF store for active storage domain
   ovirt_storage_domains:
       state: update_ovf_store
-      name: "{{ storage.name }}"
+      name: "{{ iscsi_storage['dr_' + dr_source_map + '_name'] }}"
       auth: "{{ ovirt_auth }}"
+  with_items:
+    - "{{ ovirt_storage_domains }}"
+

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -1,4 +1,8 @@
 - block:
+    - name: test
+      debug:
+              msg: "{{ dr_source_map }}"
+
     - name: Obtain SSO token
       ovirt_auth:
           url: "{{ vars['dr_sites_' + dr_source_map + '_url'] }}"
@@ -6,106 +10,107 @@
           password: "{{ vars['dr_sites_' + dr_source_map + '_password'] }}"
           ca_file: "{{ vars['dr_sites_' + dr_source_map + '_ca_file'] }}"
 
-    # Get all the running VMs and shut them down
-    - name: Fetch VMs in the setup
-      ovirt_vms_facts:
-          pattern:  status != down
-          auth: "{{ ovirt_auth }}"
-
-    - include_tasks: tasks/clean/shutdown_vms.yml vms={{ item }}
-      with_items: "{{ ovirt_vms }}"
-
-    - name: Update OVF_STORE disks for active storage domain
-      ovirt_storage_domains_facts:
-          pattern:  status = active and type != glance
-          auth: "{{ ovirt_auth }}"
+    - include_tasks: tasks/clean/shutdown_vms.yml storage={{ item }}
+      with_items:
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
     - include_tasks: tasks/clean/update_ovf_store.yml storage={{ item }}
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
-    # We do not supoport export storage domain
-    # TODO: Export storage domain should be handled by an independant task which will clean the meta data.
-    # We first remove all the non master storage domain.
-    - name: Fetch valid storage domains for detach
-      ovirt_storage_domains_facts:
-          pattern:  status = active or status = maintenance or status = unattached and type != glance
-          auth: "{{ ovirt_auth }}"
-
-    - name: Set force remove flag to false
+    - name: Set force remove flag to false for non master domains
       set_fact: dr_force=False
 
-    - include_tasks: tasks/clean/remove_domain_process.yml storage={{ item }}
+    - name: Set query for remove valid non master domains
+      # TODO: Filter only data and iso types
+      set_fact: dr_query_domain_search='status = active and type != cinder or status = maintenance and type != cinder or status = unattached and type != glance and type != cinder'
+
+    - name: Set master storage domain filter
+      set_fact: only_master=False
+
+    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
-          - "{{ ovirt_storage_domains }}"
-      when: "not item.master"
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
     # We use inactive filter only at the end, since we are not sure if there were any storage domains
     # which became inactive on the process or if there were any on the beginning.
-    - name: Fetch invalid storage domains to remove
-      ovirt_storage_domains_facts:
-          # TODO: Should check also about Cinder
-          pattern: status != active and type != glance
-          auth: "{{ ovirt_auth }}"
-
-    - name: Set force remove flag to true
+    - name: Set force remove flag to true for non master domains
       set_fact: dr_force=True
 
-    - include_tasks: tasks/clean/remove_domain_process.yml storage={{ item }}
+    - name: Set query for remove invalid non master domains
+      # TODO: Filter only data and iso types
+      set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
+
+    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
-          - "{{ ovirt_storage_domains }}"
-      when: "not item.master"
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
-    # Try to remove the master storage domains, if we fail we will try later to force remove all
-    # inactive master domains.
-    - name: Fetch valid storage domains for detach master
-      ovirt_storage_domains_facts:
-          pattern:  status = active or status = maintenance
-          auth: "{{ ovirt_auth }}"
+    - name: Set query for remove valid master domains
+      # TODO: Filter only data and iso types
+      set_fact: dr_query_domain_search='type != cinder and status = active or type != glance and type != cinder and status = maintenance'
 
-    - name: Set force remove flag to false
+    - name: Set master storage domain filter
+      set_fact: only_master=True
+
+    - name: Set force remove flag to false for master domain
       set_fact: dr_force=False
 
-    - include_tasks: tasks/clean/remove_domain_process.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
-          - "{{ ovirt_storage_domains }}"
-      when: "item.master"
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
-    # If by any chance the master storage domain is inactive we force remove it.
-    - name: Set force remove flag to true
+    - name: Set force remove flag to true for master domain
       set_fact: dr_force=True
 
-    - name: Fetch invalid storage domains to remove master
-      ovirt_storage_domains_facts:
-          pattern: status != active and type != glance
-          auth: "{{ ovirt_auth }}"
+    # If by any chance we got storage domains which are inactive we force remove them.
+    - name: Set query for remove invalid master domains
+      # TODO: Filter only data and iso types
+      set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
 
-    - include_tasks: tasks/clean/remove_domain_process.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ dr_import_storages }}"
+      loop_control:
+          loop_var: storage
 
     - name: Fetch leftover storage domains
       ovirt_storage_domains_facts:
           pattern: type != glance
           auth: "{{ ovirt_auth }}"
 
-    # Remove direct LUN disks
-    - name: Fetch leftover direct LUN disks in the setup
-      ovirt_disk_facts:
-          pattern: alias != OVF_STORE
-          auth: "{{ ovirt_auth }}"
-
-    - include_tasks: tasks/clean/remove_disks.yml disk={{ item }}
-      with_items: "{{ ovirt_disks }}"
-
-    # Remove VMs without disks only if there are no data storage domains left in the setup
+    # TODO: Document that behavior
+    # Remove VMs only if there are no data storage domains left in the setup
     - name: Fetch leftover VMs in the setup
       ovirt_vms_facts:
+          pattern: status = down
           auth: "{{ ovirt_auth }}"
-      when: "ovirt_storage_domains | length == 0"
+      when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
     - include_tasks: tasks/clean/remove_vms.yml vm={{ item }}
       with_items: "{{ ovirt_vms }}"
+      when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
+
+    # Remove direct LUN disks
+    - name: Fetch leftover direct LUN disks in the setup
+      ovirt_disk_facts:
+          pattern: disk_type = lun and number_of_vms =0
+          auth: "{{ ovirt_auth }}"
+      when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
+
+    - include_tasks: tasks/clean/remove_disks.yml disk={{ item }}
+      with_items: "{{ ovirt_disks }}"
+      when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
+
 
   # Default value is set in role defaults
   ignore_errors: "{{ dr_ignore_error_clean }}"


### PR DESCRIPTION
Fix for the following bugs:
BZ1533427 - retry remove storage domains only for active storage domains
BZ1533385 - Add the ability to clean only mapped storage domains.

Support the ability to clean only mapped storage domains by using the
following actions only for the mapped storage domains:
a) shutdown VMs which are only related mapped SDs
b) Update OVF_STORE disks for active mapped SDs
c) cleanup storage domains which are mapped

This patch follow the same concept of clean setup as before:
The flow of remove storage domains is defined in a way that is
applied seperatly to master storage domains and non-master storage domains.
the flow should be as follow:
a) Remove active non-master storage domains
b) Force remove inactive non-master storage domains
c) Remove active master storage domains
c) Force remove inactive master storage domains

Besides the mapping change, here are some changes which was done on that area
as well:

* Retry flag should be only used when storage domain is not forced detached

* Add flag of dr_clean_orphaned VMs
this parameter indicates whether to clean the entire setup
after all storage domains have been detached and removed.
The engine could still have VMs in the setup if they have no disks and
there could be disks in the setup if those are external LUN disks

* Filter out Cinder as well as Glance on engine cleanup

* Rename fact from master_filter to only_master so it will be more
meaningful. We want to indicate that we want only the master storage domains
instead of filtering out the master storage domains.