### PR TITLE
Change default value for target host and source mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Role Variables
 | dr_ignore_error_clean   | False                 | Specify whether to ignore errors on clean engine setup.<br/>This is mainly being used to avoid failures when trying to move a storage domain to maintenance/detach it.      |
 | dr_ignore_error_recover | True                  | Specify whether to ignore errors on recover.      |
 | dr_partial_import       | True                  | Specify whether to use the partial import flag on VM/Template register.<br/>If True, VMs and Templates will be registered without any missing disks, if false VMs/Templates will fail to be registered in case some of their disks will be missing from any of the storage domains.      |
-| dr_target_host          | primary               | Specify the default target host to be used in the ansible play.<br/> This hos indicates the target site which the recover process will bedone.      |
-| dr_source_map           | secondary             | Specify the default source map to be used in the play.</br/> The source map indicates the key which is used to get the target value for each attribute which we want to register with the VM/Template.       |
+| dr_target_host          | secondary             | Specify the default target host to be used in the ansible play.<br/> This host indicates the target site which the recover process will bedone.      |
+| dr_source_map           | primary               | Specify the default source map to be used in the play.</br/> The source map indicates the key which is used to get the target value for each attribute which we want to register with the VM/Template.       |
 | dr_reset_mac_pool       | True                  | If true, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
 | dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenace VM as part of a fail back scenario.       |
 | dr_cleanup_delay_maintenance       | 120                  | Specify the number of seconds between each retry as part of a fail back scenario.       |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,10 +8,10 @@ dr_ignore_error_recover: "True"
 dr_partial_import: "True"
 
 # Indicate the default target host to be used in the play.
-dr_target_host: "primary"
+dr_target_host: "secondary"
 
 # Indicate the default source map to be used in the play.
-dr_source_map: "secondary"
+dr_source_map: "primary"
 
 # Indicate whether to reset a mac pool of a VM on register.
 dr_reset_mac_pool: "True"


### PR DESCRIPTION
target site should have default value of secondary since most of the
time the fail-over process should be done to the secondary site and not
the primary site