### PR TITLE
master storage domain should be configured for each setup

### DIFF
--- a/tasks/generate_mapping.py
+++ b/tasks/generate_mapping.py
@@ -213,7 +213,7 @@ def _write_attached_storage_domains(f, dc_service, dc):
     for attached_sd in attached_sds_list:
         f.write("- dr_domain_type: %s\n" % attached_sd.storage.type)
         f.write("  dr_primary_name: %s\n" % attached_sd.name)
-        f.write("  dr_master_domain: %s\n" % attached_sd.master)
+        f.write("  dr_primary_master_domain: %s\n" % attached_sd.master)
         f.write("  dr_wipe_after_delete: %s\n"
                 % attached_sd.wipe_after_delete)
         f.write("  dr_backup: %s\n" % attached_sd.backup)
@@ -253,6 +253,7 @@ def _add_secondary_mount(f):
     f.write("  dr_secondary_path: \n")
     f.write("  dr_secondary_address: \n")
     f.write("  dr_secondary_name: \n")
+    f.write("  dr_secondary_master_domain: \n")
 
 
 def _add_secondary_scsi(f):
@@ -263,6 +264,7 @@ def _add_secondary_scsi(f):
     f.write("  dr_secondary_address: \n")
     f.write("  # target example: [\"target1\",\"target2\",\"target3\"]\n")
     f.write("  dr_secondary_target: \n")
+    f.write("  dr_secondary_master_domain: \n")
 
 
 def _add_secondary_fcp(f):
@@ -270,6 +272,7 @@ def _add_secondary_fcp(f):
             "related to the secondary site\n")
     f.write("  dr_secondary_dc_name: \n")
     f.write("  dr_secondary_name: \n")
+    f.write("  dr_secondary_master_domain: \n")
 
 
 def _write_clusters(f, clusters):

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -20,12 +20,12 @@
     - include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
         - "{{ dr_import_storages }}"
-      when: "item.dr_master_domain"
+      when: item['dr_' + dr_target_host + '_master_domain']
 
     - include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
         - "{{ dr_import_storages }}"
-      when: "not item.dr_master_domain"
+      when: not item['dr_' + dr_target_host + '_master_domain']
 
     # Get all the active storage domains in the setup to register
     # all the templates/VMs/Disks


### PR DESCRIPTION
Add the ability for the user to define a storage domain which will be master
in the primary setup and not master in secondary setup.