### PR TITLE
Print the entity report to stdout

### DIFF
--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -5,3 +5,6 @@
 
 - name: Print report
   shell: cat files/{{ dr_report_file }}
+  register: content
+
+- debug: msg="{{ content.stdout_lines | quote }}"


### PR DESCRIPTION
Make the entity report available in stdout not only
in verbose mode.

Signed-off-by: Benny Zlotnik <bzlotnik@redhat.com>