### PR TITLE
Update link for Build and test standards

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -4,5 +4,5 @@ Continuous Integration Scripts
 This directory contains scripts for Continuous Integration provided by
 [oVirt Jenkins](http://jenkins.ovirt.org/)
 system and follows the standard defined in
-[Build and test standards](http://www.ovirt.org/CI/Build_and_test_standards)
+[Build and test standards](https://ovirt-infra-docs.readthedocs.io/en/latest/CI/Build_and_test_standards/)
 wiki page.


### PR DESCRIPTION
Current link gives 404 error. Updated it with ovirt-infra-docs.readthedocs.io documentation page.