### PR TITLE
Bz1576553 -  Use query suffix for clean setup in fail back

### DIFF
--- a/files/generate_mapping.py
+++ b/files/generate_mapping.py
@@ -223,6 +223,16 @@ def _write_attached_storage_domains(f, dc_service, dc):
             f.write("#  dr_primary_dc_name: %s\n\n" % dc.name)
             continue
 
+        if (attached_sd.type == types.StorageDomainType.EXPORT):
+            f.write("# Export storage domain should not be part of the "
+                    "recovery process!\n")
+            f.write("# Please note that a data center with an export "
+                    "storage domain might reflect on the failback process.\n")
+            f.write("#- dr_domain_type: %s\n" % attached_sd.storage.type)
+            f.write("#  dr_primary_name: %s\n" % attached_sd.name)
+            f.write("#  dr_primary_dc_name: %s\n\n" % dc.name)
+            continue
+
         f.write("- dr_domain_type: %s\n" % attached_sd.storage.type)
         f.write("  dr_wipe_after_delete: %s\n"
                 % attached_sd.wipe_after_delete)

--- a/files/validator.py
+++ b/files/validator.py
@@ -73,6 +73,10 @@ class ValidateMappingFile():
         if (not self._validate_hosted_engine(python_vars)):
             self._print_finish_error()
             exit()
+
+        if (not self._validate_export_domain(python_vars)):
+            self._print_finish_error()
+            exit()
         self._print_finish_success()
 
     def _validate_lists_in_mapping_file(self, mapping_vars):
@@ -402,6 +406,18 @@ class ValidateMappingFile():
             secondary = domain['dr_secondary_name']
             if (primary == hosted or secondary == hosted):
                 print("%s%sHosted storage domains are not supported.%s"
+                      % (FAIL,
+                         PREFIX,
+                         END))
+                return False
+        return True
+
+    def _validate_export_domain(self, var_file):
+        domains = var_file[self.domain_map]
+        for domain in domains:
+            domain_type = domain['dr_storage_domain_type']
+            if domain_type == 'export':
+                print("%s%sExport storage domain is not supported.%s"
                       % (FAIL,
                          PREFIX,
                          END))

--- a/tasks/clean/remove_invalid_filtered_master_domains.yml
+++ b/tasks/clean/remove_invalid_filtered_master_domains.yml
@@ -1,11 +1,11 @@
 - block:
-    - name: Fetch storage domains for detach
+    - name: Fetch invalid storage domain for remove
       ovirt_storage_domains_facts:
-          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_query_domain_search }}
+          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_inactive_domain_search }}
           auth: "{{ ovirt_auth }}"
 
-    - name: Remove storage domain
-      include_tasks: tasks/clean/remove_domain_process.yml sd={{ item }}
+    - name: Remove invalid storage domain
+      include_tasks: tasks/clean/remove_domain_process.yml sd={{ sd }}
       with_items:
           - "{{ ovirt_storage_domains }}"
       when: (not only_master and not sd.master) or (only_master and sd.master)

--- a/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,0 +1,17 @@
+- block:
+    - name: Fetch active/maintenance/detached storage domain for remove
+      ovirt_storage_domains_facts:
+          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_active_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_maintenance_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_unattached_domain_search }}
+          auth: "{{ ovirt_auth }}"
+
+    - name: Remove valid storage domain
+      include_tasks: tasks/clean/remove_domain_process.yml sd={{ sd }}
+      with_items:
+          - "{{ ovirt_storage_domains }}"
+      when: (not only_master and not sd.master) or (only_master and sd.master)
+      loop_control:
+          loop_var: sd
+  ignore_errors: "{{ dr_ignore_error_clean }}"
+  tags:
+      - fail_back
+      - clean_engine

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -23,39 +23,41 @@
     - name: Set force remove flag to false for non master domains
       set_fact: dr_force=False
 
-    - name: Set query for remove valid non master domains
-      # TODO: Filter only data and iso types
-      set_fact: dr_query_domain_search='status = active and type != cinder or status = maintenance and type != cinder or status = unattached and type != glance and type != cinder'
+    # Set all the queries suffix to fetch a storage domain in a specific status.
+    # Note: Export storage domain is not supported and should not be part of storage mapping
+    - name: Set query suffix for active storage domains
+      set_fact: dr_active_domain_search='status = active and type != cinder'
+
+    - name: Set query suffix for maintenance storage domains
+      set_fact: dr_maintenance_domain_search='status = maintenance and type != cinder'
+
+    - name: Set query suffix for unattached storage domains
+      set_fact: dr_unattached_domain_search='status = unattached and type != cinder and type != glance'
+
+    - name: Set query for remove invalid storage domains
+      set_fact: dr_inactive_domain_search='type != glance and type != cinder and status != active'
 
     - name: Set master storage domain filter
       set_fact: only_master=False
 
     - name: Remove non master storage domains with valid statuses
-    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_valid_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
           loop_var: storage
 
     # We use inactive filter only at the end, since we are not sure if there were any storage domains
-    # which became inactive on the process or if there were any on the beginning.
+    # which became inactive on the process or if there were any at the beginning.
     - name: Set force remove flag to true for non master domains
       set_fact: dr_force=True
 
-    - name: Set query for remove invalid non master domains
-      # TODO: Filter only data and iso types
-      set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
-
     - name: Remove non master storage domains with invalid statuses using force remove
-    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_invalid_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
           loop_var: storage
-
-    - name: Set query for remove valid master domains
-      # TODO: Filter only data and iso types
-      set_fact: dr_query_domain_search='type != cinder and status = active or type != glance and type != cinder and status = maintenance'
 
     - name: Set master storage domain filter
       set_fact: only_master=True
@@ -64,7 +66,7 @@
       set_fact: dr_force=False
 
     - name: Remove master storage domains with valid statuses
-    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_valid_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -73,13 +75,8 @@
     - name: Set force remove flag to true for master domain
       set_fact: dr_force=True
 
-    # If by any chance we got storage domains which are inactive we force remove them.
-    - name: Set query for remove invalid master domains
-      # TODO: Filter only data and iso types
-      set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
-
     - name: Remove master storage domains with invalid statuses using force remove
-    - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
+    - include_tasks: tasks/clean/remove_invalid_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:


### PR DESCRIPTION
The engine clean process fetch the storage domain which is about
to be removed from oVirt using searchQuery.
This fetch operation does not support query with parentheses, therefore
to overcome that obligation each condition in the 'or' clause must also
include the storage domain name.
Also adding validation to avoid export storage domain in mapping var file
