### PR TITLE
Avoid missing dependencies when running ovirt-dr

### DIFF
--- a/files/fail_back.py
+++ b/files/fail_back.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 from bcolors import bcolors
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ConfigParser import SafeConfigParser
 import os.path
 import shlex
 import subprocess
@@ -151,8 +148,7 @@ class FailBack():
         """ Declare varialbles """
         target_host, source_map, vault, var_file, ansible_play = \
             '', '', '', '', ''
-        settings = configparser.ConfigParser()
-        settings._interpolation = configparser.ExtendedInterpolation()
+        settings = SafeConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/fail_over.py
+++ b/files/fail_over.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 from bcolors import bcolors
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ConfigParser import SafeConfigParser
 import os.path
 import shlex
 import subprocess
@@ -95,8 +92,7 @@ class FailOver():
         """ Declare varialbles """
         target_host, source_map, vault, var_file, ansible_play = \
             '', '', '', '', ''
-        settings = configparser.ConfigParser()
-        settings._interpolation = configparser.ExtendedInterpolation()
+        settings = SafeConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/generate_vars.py
+++ b/files/generate_vars.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 from bcolors import bcolors
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ConfigParser import SafeConfigParser
 import os.path
 import ovirtsdk4 as sdk
 import shlex
@@ -205,8 +202,7 @@ class GenerateMappingFile():
         """ Declare varialbles """
         site, username, password, ca_file, output_file, ansible_play = '', \
             '', '', '', '', ''
-        settings = configparser.ConfigParser()
-        settings._interpolation = configparser.ExtendedInterpolation()
+        settings = SafeConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/validator.py
+++ b/files/validator.py
@@ -2,10 +2,7 @@
 from ansible_vault import Vault
 from bcolors import bcolors
 import collections
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+from ConfigParser import SafeConfigParser
 import os.path
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
@@ -121,8 +118,7 @@ class ValidateMappingFile():
         _VAULT = 'vault'
 
         # Get default location of the yml var file.
-        settings = configparser.ConfigParser()
-        settings._interpolation = configparser.ExtendedInterpolation()
+        settings = SafeConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/validator.py
+++ b/files/validator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from ansible_vault import Vault
+from ansible.parsing.vault import VaultLib
 from bcolors import bcolors
 import collections
 from ConfigParser import SafeConfigParser
@@ -607,9 +607,9 @@ class ConnectSDK:
         self.second_ca = var_file.get('dr_sites_secondary_ca_file')
 
         if (vault_password != ''):
-            vault = Vault(vault_password)
+            vault = VaultLib(vault_password)
             try:
-                passwords = vault.load(open(pass_file).read())
+                passwords = vault.decrypt(open(pass_file).read())
                 self.primary_password = passwords['dr_sites_primary_password']
                 self.second_password = passwords['dr_sites_secondary_password']
             except BaseException:


### PR DESCRIPTION
1) Use VaultLib instead of Vault to reduce package dependecy
2) Use SafeConfigParser from ConfigParser
