### PR TITLE
Fixes related to report.log and task names

### DIFF
--- a/files/dr.conf
+++ b/files/dr.conf
@@ -16,5 +16,3 @@ dr_source_map=primary
 vault=passwords.yml
 var_file=/var/lib/ovirt-ansible-disaster-recovery/mapping_vars.yml
 ansible_play=../examples/dr_play.yml
-dr_report_file=/tmp/report.log
-

--- a/files/fail_back.py
+++ b/files/fail_back.py
@@ -131,7 +131,7 @@ class FailBack():
                     sys.stdout.write("\n" + INPUT + line + END)
                 f.write(line)
 
-        call(["cat", "report.log"])
+        call(["cat", "/tmp/report.log"])
         print("\n%s%sFinished failback operation"
               " for oVirt ansible disaster recovery%s"
               % (INFO,

--- a/files/fail_over.py
+++ b/files/fail_over.py
@@ -74,7 +74,7 @@ class FailOver():
                 if 'TASK [ovirt-ansible-disaster-recovery : ' in line:
                     sys.stdout.write("\n" + line + "\n")
                 f.write(line)
-        call(['cat', '../files/report.log'])
+        call(['cat', '/tmp/report.log'])
 
         print("\n%s%sFinished failover operation"
               " for oVirt ansible disaster recovery%s"

--- a/tasks/clean/remove_filtered_master_domains.yml
+++ b/tasks/clean/remove_filtered_master_domains.yml
@@ -4,7 +4,8 @@
           pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_query_domain_search }}
           auth: "{{ ovirt_auth }}"
 
-    - include_tasks: tasks/clean/remove_domain_process.yml sd={{ item }}
+    - name: Remove storage domain
+      include_tasks: tasks/clean/remove_domain_process.yml sd={{ item }}
       with_items:
           - "{{ ovirt_storage_domains }}"
       when: (not only_master and not sd.master) or (only_master and sd.master)

--- a/tasks/clean/shutdown_vm.yml
+++ b/tasks/clean/shutdown_vm.yml
@@ -1,5 +1,5 @@
 - block:
-    - name: Shutdown VMs
+    - name: Shutdown VM
       ovirt_vms:
           state: stopped
           name: "{{ vms.name }}"

--- a/tasks/clean/shutdown_vms.yml
+++ b/tasks/clean/shutdown_vms.yml
@@ -6,7 +6,8 @@
           auth: "{{ ovirt_auth }}"
 
     # TODO: Add a wait until the VM is really down
-    - include_tasks: tasks/clean/shutdown_vm.yml vms={{ item }}
+    - name: Shutdown VMs
+      include_tasks: tasks/clean/shutdown_vm.yml vms={{ item }}
       with_items: "{{ ovirt_vms }}"
   ignore_errors: "{{ dr_ignore_error_clean }}"
   tags:

--- a/tasks/clean/update_ovf_store.yml
+++ b/tasks/clean/update_ovf_store.yml
@@ -1,10 +1,10 @@
 - block:
-    - name: fetch storage domain only if active
+    - name: Fetch storage domain only if active
       ovirt_storage_domains_facts:
           pattern:  status = active and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}
           auth: "{{ ovirt_auth }}"
 
-    - name: update OVF store for active storage domain
+    - name: Update OVF store for active storage domain
       ovirt_storage_domains:
           state: update_ovf_store
           name: "{{ iscsi_storage['dr_' + dr_source_map + '_name'] }}"

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -6,13 +6,15 @@
           password: "{{ vars['dr_sites_' + dr_source_map + '_password'] }}"
           ca_file: "{{ vars['dr_sites_' + dr_source_map + '_ca_file'] }}"
 
-    - include_tasks: tasks/clean/shutdown_vms.yml storage={{ item }}
+    - name: Shutdown running VMs
+      include_tasks: tasks/clean/shutdown_vms.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
           loop_var: storage
 
-    - include_tasks: tasks/clean/update_ovf_store.yml storage={{ item }}
+    - name: Update OVF_STORE disk for storage domains
+      include_tasks: tasks/clean/update_ovf_store.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -28,6 +30,7 @@
     - name: Set master storage domain filter
       set_fact: only_master=False
 
+    - name: Remove non master storage domains with valid statuses
     - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
@@ -43,6 +46,7 @@
       # TODO: Filter only data and iso types
       set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
 
+    - name: Remove non master storage domains with invalid statuses using force remove
     - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
@@ -59,6 +63,7 @@
     - name: Set force remove flag to false for master domain
       set_fact: dr_force=False
 
+    - name: Remove master storage domains with valid statuses
     - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
@@ -73,6 +78,7 @@
       # TODO: Filter only data and iso types
       set_fact: dr_query_domain_search='type != glance and type != cinder and status != active'
 
+    - name: Remove master storage domains with invalid statuses using force remove
     - include_tasks: tasks/clean/remove_filtered_master_domains.yml storage={{ item }}
       with_items:
           - "{{ dr_import_storages }}"
@@ -92,7 +98,8 @@
           auth: "{{ ovirt_auth }}"
       when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
-    - include_tasks: tasks/clean/remove_vms.yml vm={{ item }}
+    - name: Remove vms if no storage domains left in setup
+      include_tasks: tasks/clean/remove_vms.yml vm={{ item }}
       with_items: "{{ ovirt_vms }}"
       when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
@@ -103,7 +110,8 @@
           auth: "{{ ovirt_auth }}"
       when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
 
-    - include_tasks: tasks/clean/remove_disks.yml disk={{ item }}
+    - name: Remove LUN disks if no storage domains left in setup
+      include_tasks: tasks/clean/remove_disks.yml disk={{ item }}
       with_items: "{{ ovirt_disks }}"
       when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,33 @@
 - block:
-    - include_tasks: unregister_entities.yml
+    - name:  Start to unregister entities
+      include_tasks: unregister_entities.yml
       tags:
           - fail_back
 
-    - include_tasks: clean_engine.yml
+    - name: Clean engine setup
+      include_tasks: clean_engine.yml
       tags:
           - fail_back
           - clean_engine
 
-    - pause:
+    - name: Failback Replication Sync pause
+      pause:
           prompt: "[Failback Replication Sync] Please press ENTER once the destination storage domains are ready to be used for the destination setup"
       tags:
           - fail_back
 
-    - include_tasks: recover_engine.yml
+    - name: Recover target engine
+      include_tasks: recover_engine.yml
       tags:
           - fail_over
           - fail_back
 
-    - include_tasks: run_unregistered_entities.yml
+    - name: Run the appropriate unregistered entities
+      include_tasks: run_unregistered_entities.yml
       tags:
           - fail_back
 
-    - include_tasks: generate_mapping.yml
+    - name: Genereate mapping var file
+      include_tasks: generate_mapping.yml
       tags:
           - generate_mapping

--- a/tasks/recover/add_domain.yml
+++ b/tasks/recover/add_domain.yml
@@ -1,5 +1,6 @@
 - block:
-    - ovirt_hosts_facts:
+    - name: Fetch available hosts in data center
+      ovirt_hosts_facts:
           pattern: "status=up and datacenter={{ storage['dr_' + dr_target_host + '_dc_name'] }}"
           auth: "{{ ovirt_auth }}"
     - block:
@@ -7,35 +8,40 @@
         fail: msg="No hosts available"
         when: ovirt_hosts.0 is undefined
     - block:
-      - include_tasks: tasks/recover/add_nfs_domain.yml
+      - name: Add NFS storage domain
+        include_tasks: tasks/recover/add_nfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'nfs'"
         loop_control:
             loop_var: nfs_storage
 
-      - include_tasks: tasks/recover/add_glusterfs_domain.yml
+      - name: Add Gluster storage domain
+        include_tasks: tasks/recover/add_glusterfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'glusterfs'"
         loop_control:
             loop_var: gluster_storage
 
-      - include_tasks: tasks/recover/add_posixfs_domain.yml
+      - name: Add posix storage domain
+        include_tasks: tasks/recover/add_posixfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'posixfs'"
         loop_control:
             loop_var: posix_storage
 
-      - include_tasks: tasks/recover/add_iscsi_domain.yml
+      - name: Add iSCSI storage domain
+        include_tasks: tasks/recover/add_iscsi_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'iscsi'"
         loop_control:
             loop_var: iscsi_storage
 
-      - include_tasks: tasks/recover/add_fcp_domain.yml
+      - name: Add FCP storage domain
+        include_tasks: tasks/recover/add_fcp_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'fcp'"

--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -2,10 +2,10 @@
     - name:
       template:
         src: report_log_template.j2
-        dest: files/{{ dr_report_file }}
+        dest: /tmp/{{ dr_report_file }}
 
     - name: Print report
-      shell: cat files/{{ dr_report_file }}
+      shell: cat /tmp/{{ dr_report_file }}
       register: content
 
     - debug: msg="{{ content.stdout_lines | quote }}"

--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -1,10 +1,10 @@
 - block:
-    - name:
+    - name: Generate log file through template
       template:
         src: report_log_template.j2
         dest: /tmp/{{ dr_report_file }}
 
-    - name: Print report
+    - name: Print report file
       shell: cat /tmp/{{ dr_report_file }}
       register: content
 

--- a/tasks/recover/register_template.yml
+++ b/tasks/recover/register_template.yml
@@ -15,12 +15,12 @@
     - name: Log append failed Template to issues failed_template_names
       set_fact:
         failed_template_names: "{{ failed_template_names }} + [ '{{ unreg_template.name }}' ]"
-      when: template_register_result | failed
+      when: template_register_result is failed
 
     - name: Log append succeed_template_names
       set_fact:
         succeed_template_names: "{{ succeed_template_names }} + [ '{{ unreg_template.name }}' ]"
-      when: template_register_result | succeeded
+      when: template_register_result is succeeded
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:
       - fail_over

--- a/tasks/recover/register_templates.yml
+++ b/tasks/recover/register_templates.yml
@@ -6,7 +6,8 @@
           storage_domain: "{{ storage.name }}"
           auth: "{{ ovirt_auth }}"
 
-    - include: tasks/recover/register_template.yml
+    - name: Register template
+      include: tasks/recover/register_template.yml
       # The main task already declared ignore errors so that might bredundant to put it here
       # ignore_errors: "{{ ignore | default(yes) }}"
       with_items: "{{ ovirt_storage_templates }}"

--- a/tasks/recover/register_vm.yml
+++ b/tasks/recover/register_vm.yml
@@ -15,6 +15,7 @@
         lun_mappings: "{{ dr_lun_map }}"
         reassign_bad_macs: "{{ dr_reset_mac_pool }}"
     register: vm_register_result
+
   - name: Log append failed VM to failed_vm_names
     set_fact:
       failed_vm_names: "{{ failed_vm_names }} + [ '{{ unreg_vm.name }}' ]"

--- a/tasks/recover/register_vm.yml
+++ b/tasks/recover/register_vm.yml
@@ -18,12 +18,12 @@
   - name: Log append failed VM to failed_vm_names
     set_fact:
       failed_vm_names: "{{ failed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
-    when: vm_register_result | failed
+    when: vm_register_result is failed
 
   - name: Log append succeed_vm_names
     set_fact:
       succeed_vm_names: "{{ succeed_vm_names }} + [ '{{ unreg_vm.name }}' ]"
-    when: vm_register_result | succeeded
+    when: vm_register_result is succeeded
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:
       - fail_over

--- a/tasks/recover/register_vms.yml
+++ b/tasks/recover/register_vms.yml
@@ -11,7 +11,8 @@
           unreg_vms: "{{ unreg_vms|default([]) }} + {{ ovirt_storage_vms }}"
 
     # TODO: We should filter out vms which were already exists in the setup (diskless VMs)
-    - include: tasks/recover/register_vm.yml
+    - name: Register VM
+      include: tasks/recover/register_vm.yml
       with_items: "{{ ovirt_storage_vms }}"
       # We use loop_control so storage.name will not be overriden by the nested loop.
       loop_control:

--- a/tasks/recover/run_vms.yml
+++ b/tasks/recover/run_vms.yml
@@ -9,12 +9,12 @@
     - name: Log append succeed_to_run_vms
       set_fact:
         succeed_to_run_vms: "{{ succeed_to_run_vms }} + [ '{{ vms.name }}' ]"
-      when: result | succeeded
+      when: result is succeeded
 
     - name: Log append failed_to_run_vms
       set_fact:
         failed_to_run_vms: "{{ failed_to_run_vms }} + [ '{{ vms.name }}' ]"
-      when: result | failed
+      when: result is failed
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:
       - fail_over

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -11,7 +11,8 @@
       shell: rm /tmp/{{ dr_report_file }}
       ignore_errors: True
 
-    - file:
+    - name: Create report file
+      file:
         path: /tmp/{{ dr_report_file }}
         state: touch
 
@@ -36,12 +37,14 @@
     # TODO: What happens if master is failed to be attached,
     # do we still want to continue and attach the other storage
     # domain (which will make another storage domain as master instead).
-    - include_tasks: tasks/recover/add_domain.yml storage={{ item }}
+    - name: Add master storage domain to the setup
+      include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
         - "{{ dr_import_storages }}"
       when: item['dr_' + dr_target_host + '_master_domain']
 
-    - include_tasks: tasks/recover/add_domain.yml storage={{ item }}
+    - name: Add non master storage domains to the setup
+      include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
         - "{{ dr_import_storages }}"
       when: not item['dr_' + dr_target_host + '_master_domain']
@@ -153,23 +156,27 @@
     # active storage domains we fetched before.
     # We register the Templates first since we might have
     # VMs which are based on them
-    - include_tasks: tasks/recover/register_templates.yml storage={{ item }}
+    - name: Register templates
+      include_tasks: tasks/recover/register_templates.yml storage={{ item }}
       with_items:
         - "{{ ovirt_storage_domains }}"
 
     # Register all the unregistered VMs after we registerd
     # all the templates from the active storage domains fetched before.
-    - include_tasks: tasks/recover/register_vms.yml storage={{ item }}
+    - name: Register VMs
+      include_tasks: tasks/recover/register_vms.yml storage={{ item }}
       with_items:
         - "{{ ovirt_storage_domains }}"
 
     # Run all the high availability VMs.
-    - include_tasks: tasks/recover/run_vms.yml vms={{ item }}
+    - name: Run highly available VMs
+      include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ unreg_vms }}"
       when: item.status == 'up' and item.high_availability.enabled | bool
 
     # Run all the rest of the VMs.
-    - include_tasks: tasks/recover/run_vms.yml vms={{ item }}
+    - name: Run the rest of the VMs
+      include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ unreg_vms }}"
       when: item.status == 'up' and not item.high_availability.enabled | bool
 
@@ -180,7 +187,8 @@
       - fail_back
 
 - always:
-     - include_tasks: tasks/recover/print_info.yml
+     - name: Print operation summary
+       include_tasks: tasks/recover/print_info.yml
      - name: Revoke the SSO token
        ovirt_auth:
            state: absent

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -8,15 +8,11 @@
       ignore_errors: False
 
     - name: Delete previous report log
-      shell: rm logs/{{ dr_report_file }}
+      shell: rm /tmp/{{ dr_report_file }}
       ignore_errors: True
 
     - file:
-        path: logs/
-        state: directory
-
-    - file:
-        path: logs/{{ dr_report_file }}
+        path: /tmp/{{ dr_report_file }}
         state: touch
 
     - name: Init entity status list
@@ -189,3 +185,6 @@
        ovirt_auth:
            state: absent
            ovirt_auth: "{{ ovirt_auth }}"
+  tags:
+      - fail_over
+      - fail_back

--- a/tasks/run_unregistered_entities.yml
+++ b/tasks/run_unregistered_entities.yml
@@ -6,12 +6,13 @@
           password: "{{ vars['dr_sites_' + dr_target_host + '_password'] }}"
           ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
 
-    # Run all the high availability VMs.
-    - include_tasks: tasks/recover/run_vms.yml vms={{ item }}
+    - name: Run all the high availability VMs
+      include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ running_vms_fail_back }}"
       when: item.high_availability.enabled | bool
 
-    - include_tasks: tasks/recover/run_vms.yml vms={{ item }}
+    - name: Run all the entire running VMs
+      include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ running_vms_fail_back }}"
       when: not item.high_availability.enabled | bool
 


### PR DESCRIPTION
1) Use report log in the tmp folder instead of files since we print this
already as part failover and failback scripts
2) Change deprecated succeeded/failed conditions
3) Set missing names for tasks with missing names