### PR TITLE
Force remove storage domains which are in maintenance

### DIFF
--- a/tasks/clean/remove_invalid_filtered_master_domains.yml
+++ b/tasks/clean/remove_invalid_filtered_master_domains.yml
@@ -1,7 +1,11 @@
 - block:
     - name: Fetch invalid storage domain for remove
       ovirt_storage_domains_facts:
+          # BZ1589535 - storage domains which fail to be removed gracefully due to VMs in Preview
+          # or VMs which are delete protected should be retried with the force removed flag
+          # That is why we also try to force remove storage domain in maintenance.
           pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_inactive_domain_search }}
+                    or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_maintenance_domain_search }}
           auth: "{{ ovirt_auth }}"
 
     - name: Remove invalid storage domain

--- a/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,7 +1,9 @@
 - block:
     - name: Fetch active/maintenance/detached storage domain for remove
       ovirt_storage_domains_facts:
-          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_active_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_maintenance_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_unattached_domain_search }}
+          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_active_domain_search }}
+                    or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_maintenance_domain_search }}
+                    or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_unattached_domain_search }}
           auth: "{{ ovirt_auth }}"
 
     - name: Remove valid storage domain


### PR DESCRIPTION
The oVirt dr should try to clean storage domains which are in
maintenance with the force flag in case there are VMs which are deleted
protected or VMs which are in preview.