### PR TITLE
Support unregistered entities in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Role Variables
 | dr_reset_mac_pool       | True                  | If true, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
 | dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenace VM as part of a fail back scenario.       |
 | dr_cleanup_delay_maintenance       | 120                  | Specify the number of seconds between each retry as part of a fail back scenario.       |
-| dr_clean_orphaned_vms:       | True                  | Specify whether to remove any VMs which have no disks from the setup as part of cleanup.       |
-| dr_clean_orphaned_disks:       | True                  | Specify whether to remove lun disks from the setup as part of engine setup.       |
+| dr_clean_orphaned_vms        | True                  | Specify whether to remove any VMs which have no disks from the setup as part of cleanup.       |
+| dr_clean_orphaned_disks        | True                  | Specify whether to remove lun disks from the setup as part of engine setup.       |
+| dr_running_vms		 | /tmp/ovirt_dr_running_vm_list	 | Specify the file path which is used to contain the data of the running VMs in the secondary setup before the failback process run on the primary setup after the secondary site cleanup was finished. Note that the /tmp folder is being used as default so the file will not be available after system reboot.
+
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,3 +30,8 @@ dr_clean_orphaned_disks: "True"
 
 # Indicate the default entities status report file name
 dr_report_file: "report.log"
+
+# Indicate the file name which is used to contain the data of the running VMs in the secondary setup before the failback
+# run again on the primary setup after the failback will be finished.
+# Note that the /tmp folder is being used as default so the file will not be available after system reboot.
+dr_running_vms: "/tmp/ovirt_dr_running_vm_list"

--- a/files/fail_back.py
+++ b/files/fail_back.py
@@ -77,7 +77,8 @@ class FailBack():
 
         # Setting vault password
         vault_pass = raw_input(
-            INPUT + PREFIX + "Please enter the vault password: " + END)
+            INPUT + PREFIX + "Please enter vault password (In case of "
+            "plain text please press ENTER): " + END)
         os.system("export vault_password=\"" + vault_pass + "\"")
         log.info("Starting cleanup process of setup %s"
                  " for oVirt ansible disaster recovery" % target_host)

--- a/files/validator.py
+++ b/files/validator.py
@@ -22,8 +22,10 @@ class ValidateMappingFile():
 
     def_var_file = "/var/lib/ovirt-ansible-disaster-" \
                    "recovery/mapping_vars.yml"
+    default_main_file = "../defaults/main.yml"
     var_file = ""
     vault = ""
+    running_vms = "dr_running_vms"
     cluster_map = 'dr_cluster_mappings'
     domain_map = 'dr_import_storages'
     role_map = 'dr_role_mappings'
@@ -63,7 +65,8 @@ class ValidateMappingFile():
 
         if (not self._validate_lists_in_mapping_file(python_vars) or
             not self._validate_duplicate_keys(python_vars) or not
-                self._entity_validator(python_vars)):
+                self._entity_validator(python_vars) or not
+                self._validate_failback_leftovers()):
             self._print_finish_error()
             exit()
 
@@ -105,7 +108,7 @@ class ValidateMappingFile():
                  END))
 
     def _print_finish_success(self):
-        print("%s%sFinished validation variable mapping file "
+        print("%s%sFinished validation of variable mapping file "
               "for oVirt ansible disaster recovery%s"
               % (INFO,
                  PREFIX,
@@ -193,6 +196,57 @@ class ValidateMappingFile():
                     second_conn.close()
 
         return isValid
+
+    def _validate_failback_leftovers(self):
+        valid = {"yes": True, "y": True, "ye": True,
+                 "no": False, "n": False}
+        with open(self.default_main_file, 'r') as stream:
+            try:
+                info_dict = yaml.load(stream)
+                running_vms_file = info_dict.get(self.running_vms)
+                if os.path.isfile(running_vms_file):
+                    ans = raw_input(
+                        "%s%sFile with running vms info already exists from "
+                        "previous failback operation. Do you want to "
+                        "delete it(yes,no)?: %s" %
+                        (WARN,
+                         PREFIX,
+                         END))
+                    ans = ans.lower()
+                    if ans in valid and valid[ans]:
+                        os.remove(running_vms_file)
+                        print("%s%sFile '%s' has been deleted"
+                              " successfully%s" %
+                              (INFO,
+                               PREFIX,
+                               running_vms_file,
+                               END))
+                    else:
+                        print("%s%sFile '%s' has not been deleted."
+                              " It will be used in the next failback"
+                              " operation%s" %
+                              (INFO,
+                               PREFIX,
+                               running_vms_file,
+                               END))
+
+            except yaml.YAMLError as exc:
+                print("%s%syaml file '%s' could not be loaded%s"
+                      % (FAIL,
+                         PREFIX,
+                         self.default_main_file,
+                         END))
+                print(exc)
+                return False
+            except OSError as ex:
+                print("%s%sFail to validate failback running vms file '%s'%s"
+                      % (FAIL,
+                         PREFIX,
+                         self.default_main_file,
+                         END))
+                print(ex)
+                return False
+        return True
 
     def _validate_entities_in_setup(self, conn, setup, python_vars):
         isValid = True

--- a/tasks/clean/remove_domain_process.yml
+++ b/tasks/clean/remove_domain_process.yml
@@ -32,7 +32,7 @@
 
     - name: Remove storage domain with no force
       include_tasks: tasks/clean/remove_domain.yml host={{ ovirt_hosts[0].id }}
-      when: "ovirt_hosts is defined and ovirt_hosts|length > 0 and not force"
+      when: "ovirt_hosts is defined and ovirt_hosts|length > 0 and not dr_force"
 
     - name: Force remove storage domain
       include_tasks: tasks/clean/remove_domain.yml host="00000000-0000-0000-0000-000000000000"

--- a/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,7 +1,9 @@
 - block:
     - name: Fetch active/maintenance/detached storage domain for remove
       ovirt_storage_domains_facts:
-          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_active_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_maintenance_domain_search }} or name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_unattached_domain_search }}
+          pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_active_domain_search }} or
+                    name={{ storage['dr_' + dr_source_map + '_name'] }} and datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }} and {{ dr_maintenance_domain_search }} or
+                    name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_unattached_domain_search }}
           auth: "{{ ovirt_auth }}"
 
     - name: Remove valid storage domain

--- a/tasks/clean/shutdown_vms.yml
+++ b/tasks/clean/shutdown_vms.yml
@@ -2,7 +2,7 @@
     # Get all the running VMs related to a storage domain and shut them down
     - name: Fetch VMs in the storage domain
       ovirt_vms_facts:
-          pattern:  status != down and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}
+          pattern:  status != down and storage.name={{ storage['dr_' + dr_source_map + '_name'] }} and datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }}
           auth: "{{ ovirt_auth }}"
 
     # TODO: Add a wait until the VM is really down

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -20,14 +20,14 @@
 
     - name: Init entity status list
       set_fact:
-        failed_vm_names: []
-        succeed_vm_names: []
-        failed_template_names: []
-        succeed_template_names: []
-        failed_to_run_vms: []
-        succeed_to_run_vms: []
-        succeed_storage_domains: []
-        failed_storage_domains: []
+          failed_vm_names: []
+          succeed_vm_names: []
+          failed_template_names: []
+          succeed_template_names: []
+          failed_to_run_vms: []
+          succeed_to_run_vms: []
+          succeed_storage_domains: []
+          failed_storage_domains: []
 
     # TODO: We should add a validation task that will validate whether
     # all the hosts in the other site (primary or secondary) could not be connected
@@ -42,13 +42,13 @@
     - name: Add master storage domain to the setup
       include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
-        - "{{ dr_import_storages }}"
+          - "{{ dr_import_storages }}"
       when: item['dr_' + dr_target_host + '_master_domain']
 
     - name: Add non master storage domains to the setup
       include_tasks: tasks/recover/add_domain.yml storage={{ item }}
       with_items:
-        - "{{ dr_import_storages }}"
+          - "{{ dr_import_storages }}"
       when: not item['dr_' + dr_target_host + '_master_domain']
 
     # Get all the active storage domains in the setup to register
@@ -70,87 +70,87 @@
 
     - name: Set Cluster Map
       set_fact:
-              dr_cluster_map: "{{ dr_cluster_map }} + {{ [
-              {
-                  'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
-                  'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
-              }
+          dr_cluster_map: "{{ dr_cluster_map }} + {{ [
+          {
+              'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
+              'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
+          }
           ] }}"
       with_items: "{{ dr_cluster_mappings }}"
       when: dr_cluster_mappings is not none
 
     - name: Set Affinity Group Map
       set_fact:
-              dr_affinity_group_map: "{{ dr_affinity_group_map }} + {{ [
-              {
-                  'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
-                  'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
-              }
+          dr_affinity_group_map: "{{ dr_affinity_group_map }} + {{ [
+          {
+              'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
+              'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
+          }
           ] }}"
       with_items: "{{ dr_affinity_group_mappings }}"
       when: dr_affinity_group_mappings is not none
 
     - name: Set Network Map
       set_fact:
-              dr_network_map: "{{ dr_network_map }} + {{ [
-              {
-                  'source_network_name': item[dr_source_map + '_network_name'] | default('EMPTY_ELEMENT', true),
-                  'source_profile_name': item[dr_source_map + '_profile_name'] | default('EMPTY_ELEMENT', true),
-                  'target_network_dc': item[dr_target_host + '_network_dc'] | default('EMPTY_ELEMENT', true),
-                  'target_profile_id': item[dr_target_host + '_profile_id'] | default('00000000-0000-0000-0000-000000000000', true)
-              }
+          dr_network_map: "{{ dr_network_map }} + {{ [
+          {
+              'source_network_name': item[dr_source_map + '_network_name'] | default('EMPTY_ELEMENT', true),
+              'source_profile_name': item[dr_source_map + '_profile_name'] | default('EMPTY_ELEMENT', true),
+              'target_network_dc': item[dr_target_host + '_network_dc'] | default('EMPTY_ELEMENT', true),
+              'target_profile_id': item[dr_target_host + '_profile_id'] | default('00000000-0000-0000-0000-000000000000', true)
+          }
           ] }}"
       with_items: "{{ dr_network_mappings }}"
       when: dr_network_mappings is not none
 
     - name: Set Affinity Label Map
       set_fact:
-              dr_affinity_label_map: "{{ dr_affinity_label_map }} + {{ [
-              {
-                  'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
-                  'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
-              }
+          dr_affinity_label_map: "{{ dr_affinity_label_map }} + {{ [
+          {
+              'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
+              'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
+          }
           ] }}"
       with_items: "{{ dr_affinity_label_mappings }}"
       when: dr_affinity_label_mappings is not none
 
     - name: Set aaa extensions Map
       set_fact:
-              dr_domain_map: "{{ dr_domain_map }} + {{ [
-              {
-                  'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
-                  'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
-              }
+          dr_domain_map: "{{ dr_domain_map }} + {{ [
+          {
+              'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
+              'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
+          }
           ] }}"
       with_items: "{{ dr_domain_mappings }}"
       when: dr_domain_mappings is not none
 
     - name: Set Role Map
       set_fact:
-              dr_role_map: "{{ dr_role_map }} + {{ [
-              {
-                  'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
-                  'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
-              }
+          dr_role_map: "{{ dr_role_map }} + {{ [
+          {
+              'source_name': item[dr_source_map + '_name'] | default('EMPTY_ELEMENT', true),
+              'dest_name': item[dr_target_host + '_name'] | default('EMPTY_ELEMENT', true)
+          }
           ] }}"
       with_items: "{{ dr_role_mappings }}"
       when: dr_role_mappings is not none
 
     - name: Set Lun Map
       set_fact:
-              dr_lun_map: "{{ dr_lun_map }} + {{ [
-              {
-                  'source_logical_unit_id': item[dr_source_map + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
-                  'source_storage_type': item[dr_source_map + '_storage_type'] | default('EMPTY_ELEMENT', true),
-                  'dest_logical_unit_id': item[dr_target_host + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
-                  'dest_storage_type': item[dr_target_host + '_storage_type'] | default('EMPTY_ELEMENT', true),
-                  'dest_logical_unit_address': item[dr_target_host + '_logical_unit_address'] | default('EMPTY_ELEMENT', true),
-                  'dest_logical_unit_port': item[dr_target_host + '_logical_unit_port'] | default('3260'|int, true),
-                  'dest_logical_unit_portal': item[dr_target_host + '_logical_unit_portal'] | default('1', true),
-                  'dest_logical_unit_username': item[dr_target_host + '_logical_unit_username'] | default('', true),
-                  'dest_logical_unit_password': item[dr_target_host + '_logical_unit_password'] | default('', true),
-                  'dest_logical_unit_target': item[dr_target_host + '_logical_unit_target'] | default('[]', true)
-              }
+          dr_lun_map: "{{ dr_lun_map }} + {{ [
+          {
+              'source_logical_unit_id': item[dr_source_map + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
+              'source_storage_type': item[dr_source_map + '_storage_type'] | default('EMPTY_ELEMENT', true),
+              'dest_logical_unit_id': item[dr_target_host + '_logical_unit_id'] | default('EMPTY_ELEMENT', true),
+              'dest_storage_type': item[dr_target_host + '_storage_type'] | default('EMPTY_ELEMENT', true),
+              'dest_logical_unit_address': item[dr_target_host + '_logical_unit_address'] | default('EMPTY_ELEMENT', true),
+              'dest_logical_unit_port': item[dr_target_host + '_logical_unit_port'] | default('3260'|int, true),
+              'dest_logical_unit_portal': item[dr_target_host + '_logical_unit_portal'] | default('1', true),
+              'dest_logical_unit_username': item[dr_target_host + '_logical_unit_username'] | default('', true),
+              'dest_logical_unit_password': item[dr_target_host + '_logical_unit_password'] | default('', true),
+              'dest_logical_unit_target': item[dr_target_host + '_logical_unit_target'] | default('[]', true)
+          }
           ] }}"
       with_items: "{{ dr_lun_mappings }}"
       when: dr_lun_mappings is not none
@@ -162,14 +162,14 @@
     - name: Register templates
       include_tasks: tasks/recover/register_templates.yml storage={{ item }}
       with_items:
-        - "{{ ovirt_storage_domains }}"
+          - "{{ ovirt_storage_domains }}"
 
     # Register all the unregistered VMs after we registerd
     # all the templates from the active storage domains fetched before.
     - name: Register VMs
       include_tasks: tasks/recover/register_vms.yml storage={{ item }}
       with_items:
-        - "{{ ovirt_storage_domains }}"
+          - "{{ ovirt_storage_domains }}"
 
     # Run all the high availability VMs.
     - name: Run highly available VMs

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -8,13 +8,15 @@
       ignore_errors: False
 
     - name: Delete previous report log
-      shell: rm /tmp/{{ dr_report_file }}
+      file:
+          path: "/tmp/{{ dr_report_file }}"
+          state: absent
       ignore_errors: True
 
     - name: Create report file
       file:
-        path: /tmp/{{ dr_report_file }}
-        state: touch
+          path: "/tmp/{{ dr_report_file }}"
+          state: touch
 
     - name: Init entity status list
       set_fact:

--- a/tasks/run_unregistered_entities.yml
+++ b/tasks/run_unregistered_entities.yml
@@ -6,6 +6,14 @@
           password: "{{ vars['dr_sites_' + dr_target_host + '_password'] }}"
           ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
 
+    - name: Read file that contains running VMs from the previous setup
+      set_fact: running_vms_fail_back="{{ lookup('file', '{{ dr_running_vms }}') }}"
+
+    - name: Remove dr_running_vms file after being used
+      file:
+          path: "{{ dr_running_vms }}"
+          state: absent
+
     - name: Run all the high availability VMs
       include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ running_vms_fail_back }}"
@@ -15,6 +23,8 @@
       include_tasks: tasks/recover/run_vms.yml vms={{ item }}
       with_items: "{{ running_vms_fail_back }}"
       when: not item.high_availability.enabled | bool
+
+    # TODO: Remove dr_report_file
 
   ignore_errors: "{{ dr_ignore_error_clean }}"
   tags:

--- a/tasks/unregister_entities.yml
+++ b/tasks/unregister_entities.yml
@@ -12,9 +12,41 @@
           pattern:  status = up
           auth: "{{ ovirt_auth }}"
 
-    # TODO: Should be written to a file
-    - name: Define running VMs
-      set_fact: running_vms_fail_back="{{ ovirt_vms }}"
+    - name: Check whether file with running VMs info exists
+      stat:
+          path: '{{ dr_running_vms }}'
+      register: stat_result
+
+    - name: Fetch all data of running VMs from file, if exists.
+      set_fact: running_vms_fail_back="{{ lookup('file', '{{ dr_running_vms }}') }}"
+      when: stat_result.stat.exists
+      ignore_errors: True
+
+    - name: Init list property for running_vms
+      set_fact:
+          res_ovirt_vms="[]"
+
+    - name: Map all running vms in fact
+      set_fact:
+          res_ovirt_vms: "{{ res_ovirt_vms }} + {{ [
+              {
+                  'id': item.id,
+                  'name': item.name,
+                  'high_availability': item.high_availability
+              }
+          ] }}"
+      with_items: "{{ ovirt_vms }}"
+      when: item.id is defined
+
+    - name: Create file to obtain running vms if file does not exist
+      file:
+        path: '{{ dr_running_vms }}'
+        state: touch
+      when: stat_result.stat.exists == False or running_vms_fail_back is not defined
+
+    - name: If no file exists which contains data of unregistered VMs, set the file with running VMs
+      copy: content="{{ res_ovirt_vms }}" dest={{ dr_running_vms }}
+      when: running_vms_fail_back is not defined or (running_vms_fail_back is defined and running_vms_fail_back | length == 0)
 
   ignore_errors: "{{ dr_ignore_error_clean }}"
   tags:


### PR DESCRIPTION
Preserve the VMs statuses in a seperate file instead in the memory, so in case the failback operation will fail in the middle the admin will still have the information about the VMs that ran before on the secondary site