### PR TITLE
python, warnings: Eliminate usages of the deprecated DeprecationWarning

### DIFF
--- a/files/fail_back.py
+++ b/files/fail_back.py
@@ -1,8 +1,4 @@
 #!/usr/bin/python3
-try:
-    from ConfigParser import SafeConfigParser
-except ModuleNotFoundError:
-    from configparser import SafeConfigParser
 import logging
 import os.path
 import subprocess
@@ -10,6 +6,7 @@ from subprocess import call
 import sys
 import time
 
+from configparser import ConfigParser
 from six.moves import input
 
 from bcolors import bcolors
@@ -191,7 +188,7 @@ class FailBack():
         """ Declare varialbles """
         target_host, source_map, vault, var_file, ansible_play = \
             '', '', '', '', ''
-        settings = SafeConfigParser()
+        settings = ConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/fail_over.py
+++ b/files/fail_over.py
@@ -1,8 +1,4 @@
 #!/usr/bin/python3
-try:
-    from ConfigParser import SafeConfigParser
-except ModuleNotFoundError:
-    from configparser import SafeConfigParser
 import logging
 import os.path
 import subprocess
@@ -10,6 +6,7 @@ from subprocess import call
 import sys
 import time
 
+from configparser import ConfigParser
 from six.moves import input
 
 from bcolors import bcolors
@@ -132,7 +129,7 @@ class FailOver():
         """ Declare varialbles """
         target_host, source_map, vault, var_file, ansible_play = \
             '', '', '', '', ''
-        settings = SafeConfigParser()
+        settings = ConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/generate_vars.py
+++ b/files/generate_vars.py
@@ -1,13 +1,10 @@
 #!/usr/bin/python3
-try:
-    from ConfigParser import SafeConfigParser
-except ModuleNotFoundError:
-    from configparser import SafeConfigParser
-
 import logging
 import os.path
 import subprocess
 import sys
+
+from configparser import ConfigParser
 from six.moves import input
 
 import ovirtsdk4 as sdk
@@ -211,7 +208,7 @@ class GenerateMappingFile():
         """ Declare varialbles """
         site, username, password, ca_file, output_file, ansible_play = '', \
             '', '', '', '', ''
-        settings = SafeConfigParser()
+        settings = ConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)

--- a/files/ovirt-dr
+++ b/files/ovirt-dr
@@ -1,14 +1,11 @@
 #!/usr/bin/python3
-try:
-    from ConfigParser import SafeConfigParser
-except ModuleNotFoundError:
-    from configparser import SafeConfigParser
 import logging as logg
 import os
 import sys
 import time
 import getopt
 
+from configparser import ConfigParser
 from six.moves import input
 
 import fail_back
@@ -111,7 +108,7 @@ def _get_log_conf(conf_file, log_file, log_level):
         conf_file = input(
             "Conf file '" + conf_file + "' does not exist."
             " Please provide the configuration file location: ")
-    settings = SafeConfigParser()
+    settings = ConfigParser()
     settings.read(conf_file)
     if log_section not in settings.sections():
         settings.add_section(log_section)

--- a/files/validator.py
+++ b/files/validator.py
@@ -1,11 +1,8 @@
 #!/usr/bin/python3
-try:
-    from ConfigParser import SafeConfigParser
-except ModuleNotFoundError:
-    from configparser import SafeConfigParser
-import os.path
 
+from configparser import ConfigParser
 from six.moves import input
+
 import ovirtsdk4 as sdk
 import ovirtsdk4.types as types
 import yaml
@@ -127,7 +124,7 @@ class ValidateMappingFile():
         _VAR_FILE = 'var_file'
 
         # Get default location of the yml var file.
-        settings = SafeConfigParser()
+        settings = ConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
             settings.add_section(_SECTION)


### PR DESCRIPTION
Using "ConfigParser" instead of the deprecated (since Python 3.2)
"SafeConfigParser" to fix warnings like the following one:
./ovirt-dr:114: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.

Signed-off-by: Pavel Bar <pbar@redhat.com>