### PR TITLE
Fix ansible_lint tox test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = -r{toxinidir}/tests/requirements.txt
 whitelist_externals =
     bash
 commands =
-    bash -c "find {toxinidir}/tasks -name *.yml | xargs ansible-lint"
+    bash -c "ansible-lint {toxinidir} -x 106"
 
 [testenv:pycodestyle]
 whitelist_externals =


### PR DESCRIPTION
This fixes the ansible-lint tests.
I have added the `-x 106` to ignore the wrong name of the role/repository. 