### PR TITLE
CI, tox: fixing CI errors produced by ansible_lint

### DIFF
--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -5,7 +5,7 @@
         dest: /tmp/{{ dr_report_file }}
 
     - name: Print report file
-      shell: cat /tmp/{{ dr_report_file }}
+      command: cat /tmp/{{ dr_report_file }}
       register: content
 
     - name: Pring report file to stdout

--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -3,6 +3,7 @@
       template:
         src: report_log_template.j2
         dest: /tmp/{{ dr_report_file }}
+        mode: preserve
 
     - name: Print report file
       command: cat /tmp/{{ dr_report_file }}

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -17,6 +17,7 @@
       file:
           path: "/tmp/{{ dr_report_file }}"
           state: touch
+          mode: 0644
 
     - name: Init entity status list
       set_fact:

--- a/tasks/run_unregistered_entities.yml
+++ b/tasks/run_unregistered_entities.yml
@@ -7,7 +7,7 @@
           ca_file: "{{ vars['dr_sites_' + dr_target_host + '_ca_file'] }}"
 
     - name: Read file that contains running VMs from the previous setup
-      set_fact: running_vms_fail_back="{{ lookup('file', '{{ dr_running_vms }}') }}"
+      set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
 
     - name: Remove dr_running_vms file after being used
       file:

--- a/tasks/unregister_entities.yml
+++ b/tasks/unregister_entities.yml
@@ -42,10 +42,11 @@
       file:
         path: '{{ dr_running_vms }}'
         state: touch
+        mode: 0644
       when: not stat_result.stat.exists|bool or running_vms_fail_back is not defined
 
     - name: If no file exists which contains data of unregistered VMs, set the file with running VMs
-      copy: content="{{ res_ovirt_vms }}" dest={{ dr_running_vms }}
+      copy: content="{{ res_ovirt_vms }}" dest={{ dr_running_vms }} mode="preserve"
       when: running_vms_fail_back is not defined or (running_vms_fail_back is defined and running_vms_fail_back | length == 0)
 
   ignore_errors: "{{ dr_ignore_error_clean }}"

--- a/tasks/unregister_entities.yml
+++ b/tasks/unregister_entities.yml
@@ -18,7 +18,7 @@
       register: stat_result
 
     - name: Fetch all data of running VMs from file, if exists.
-      set_fact: running_vms_fail_back="{{ lookup('file', '{{ dr_running_vms }}') }}"
+      set_fact: running_vms_fail_back="{{ lookup('file', dr_running_vms) }}"
       when: stat_result.stat.exists
       ignore_errors: True
 


### PR DESCRIPTION
Fixing the following errors:
  [207] Nested jinja pattern
  [208] File permissions not mentioned
  [305] Use shell only when shell functionality is required

Signed-off-by: Pavel Bar <pbar@redhat.com>