### PR TITLE
CI, tox: fixing CI warnings produced by ansible_lint

### DIFF
--- a/tasks/clean/remove_domain_process.yml
+++ b/tasks/clean/remove_domain_process.yml
@@ -31,13 +31,13 @@
       when: sp_uuid
 
     - name: Remove storage domain with no force
-      include_tasks: tasks/clean/remove_domain.yml
+      include_tasks: remove_domain.yml
       vars:
           host: "{{ ovirt_hosts[0].id }}"
       when: "ovirt_hosts is defined and ovirt_hosts|length > 0 and not dr_force"
 
     - name: Force remove storage domain
-      include_tasks: tasks/clean/remove_domain.yml
+      include_tasks: remove_domain.yml
       vars:
           host: "00000000-0000-0000-0000-000000000000"
       when: "dr_force"

--- a/tasks/clean/remove_invalid_filtered_master_domains.yml
+++ b/tasks/clean/remove_invalid_filtered_master_domains.yml
@@ -5,7 +5,7 @@
           auth: "{{ ovirt_auth }}"
 
     - name: Remove invalid storage domain
-      include_tasks: tasks/clean/remove_domain_process.yml
+      include_tasks: remove_domain_process.yml
       vars:
           sd: "{{ sd }}"
       with_items:

--- a/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -11,7 +11,7 @@
           auth: "{{ ovirt_auth }}"
 
     - name: Remove valid storage domain
-      include_tasks: tasks/clean/remove_domain_process.yml
+      include_tasks: remove_domain_process.yml
       vars:
           sd: "{{ sd }}"
       with_items:

--- a/tasks/clean/shutdown_vms.yml
+++ b/tasks/clean/shutdown_vms.yml
@@ -10,7 +10,7 @@
 
     # TODO: Add a wait until the VM is really down
     - name: Shutdown VMs
-      include_tasks: tasks/clean/shutdown_vm.yml
+      include_tasks: shutdown_vm.yml
       vars:
           vms: "{{ item }}"
       with_items: "{{ ovirt_vms }}"

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -7,7 +7,7 @@
           ca_file: "{{ vars['dr_sites_' + dr_source_map + '_ca_file'] }}"
 
     - name: Shutdown running VMs
-      include_tasks: tasks/clean/shutdown_vms.yml
+      include_tasks: clean/shutdown_vms.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -16,7 +16,7 @@
           loop_var: storage
 
     - name: Update OVF_STORE disk for storage domains
-      include_tasks: tasks/clean/update_ovf_store.yml
+      include_tasks: clean/update_ovf_store.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -40,7 +40,7 @@
       set_fact: only_master=False
 
     - name: Remove non master storage domains with valid statuses
-      include_tasks: tasks/clean/remove_valid_filtered_master_domains.yml
+      include_tasks: clean/remove_valid_filtered_master_domains.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -54,7 +54,7 @@
       set_fact: dr_force=True
 
     - name: Remove non master storage domains with invalid statuses using force remove
-      include_tasks: tasks/clean/remove_invalid_filtered_master_domains.yml
+      include_tasks: clean/remove_invalid_filtered_master_domains.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -69,7 +69,7 @@
       set_fact: dr_force=False
 
     - name: Remove master storage domains with valid statuses
-      include_tasks: tasks/clean/remove_valid_filtered_master_domains.yml
+      include_tasks: clean/remove_valid_filtered_master_domains.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -81,7 +81,7 @@
       set_fact: dr_force=True
 
     - name: Remove master storage domains with invalid statuses using force remove
-      include_tasks: tasks/clean/remove_invalid_filtered_master_domains.yml
+      include_tasks: clean/remove_invalid_filtered_master_domains.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -103,7 +103,7 @@
       when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
     - name: Remove vms if no storage domains left in setup
-      include_tasks: tasks/clean/remove_vms.yml
+      include_tasks: clean/remove_vms.yml
       vars:
           vm: "{{ item }}"
       with_items: "{{ ovirt_vms }}"
@@ -117,7 +117,7 @@
       when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
 
     - name: Remove LUN disks if no storage domains left in setup
-      include_tasks: tasks/clean/remove_disks.yml
+      include_tasks: clean/remove_disks.yml
       vars:
           disk: "{{ item }}"
       with_items: "{{ ovirt_disks }}"

--- a/tasks/recover/add_domain.yml
+++ b/tasks/recover/add_domain.yml
@@ -9,7 +9,7 @@
         when: ovirt_hosts.0 is undefined
     - block:
       - name: Add storage domain if NFS
-        include_tasks: tasks/recover/add_nfs_domain.yml
+        include_tasks: add_nfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'nfs'"
@@ -17,7 +17,7 @@
             loop_var: nfs_storage
 
       - name: Add storage domain if Gluster
-        include_tasks: tasks/recover/add_glusterfs_domain.yml
+        include_tasks: add_glusterfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'glusterfs'"
@@ -25,7 +25,7 @@
             loop_var: gluster_storage
 
       - name: Add storage domain if Posix
-        include_tasks: tasks/recover/add_posixfs_domain.yml
+        include_tasks: add_posixfs_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'posixfs'"
@@ -33,7 +33,7 @@
             loop_var: posix_storage
 
       - name: Add storage domain is scsi
-        include_tasks: tasks/recover/add_iscsi_domain.yml
+        include_tasks: add_iscsi_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'iscsi'"
@@ -41,7 +41,7 @@
             loop_var: iscsi_storage
 
       - name: Add storage domain if fcp
-        include_tasks: tasks/recover/add_fcp_domain.yml
+        include_tasks: add_fcp_domain.yml
         with_items:
           - "{{ storage }}"
         when: "storage.dr_domain_type == 'fcp'"

--- a/tasks/recover/print_info.yml
+++ b/tasks/recover/print_info.yml
@@ -9,7 +9,7 @@
       command: cat /tmp/{{ dr_report_file }}
       register: content
 
-    - name: Pring report file to stdout
+    - name: Print report file to stdout
       debug: msg="{{ content.stdout_lines | quote }}"
   tags:
       - fail_over

--- a/tasks/recover/register_templates.yml
+++ b/tasks/recover/register_templates.yml
@@ -7,7 +7,7 @@
           auth: "{{ ovirt_auth }}"
 
     - name: Register template
-      include: tasks/recover/register_template.yml
+      include: register_template.yml
       # The main task already declared ignore errors so that might bredundant to put it here
       # ignore_errors: "{{ ignore | default(yes) }}"
       with_items: "{{ ovirt_storage_templates }}"

--- a/tasks/recover/register_vms.yml
+++ b/tasks/recover/register_vms.yml
@@ -12,7 +12,7 @@
 
     # TODO: We should filter out vms which were already exists in the setup (diskless VMs)
     - name: Register VM
-      include: tasks/recover/register_vm.yml
+      include: register_vm.yml
       with_items: "{{ ovirt_storage_vms }}"
       # We use loop_control so storage.name will not be overriden by the nested loop.
       loop_control:

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -41,7 +41,7 @@
     # do we still want to continue and attach the other storage
     # domain (which will make another storage domain as master instead).
     - name: Add master storage domain to the setup
-      include_tasks: tasks/recover/add_domain.yml
+      include_tasks: recover/add_domain.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -49,7 +49,7 @@
       when: item['dr_' + dr_target_host + '_master_domain']
 
     - name: Add non master storage domains to the setup
-      include_tasks: tasks/recover/add_domain.yml
+      include_tasks: recover/add_domain.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -165,7 +165,7 @@
     # We register the Templates first since we might have
     # VMs which are based on them
     - name: Register templates
-      include_tasks: tasks/recover/register_templates.yml
+      include_tasks: recover/register_templates.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -174,7 +174,7 @@
     # Register all the unregistered VMs after we registerd
     # all the templates from the active storage domains fetched before.
     - name: Register VMs
-      include_tasks: tasks/recover/register_vms.yml
+      include_tasks: recover/register_vms.yml
       vars:
           storage: "{{ item }}"
       with_items:
@@ -182,7 +182,7 @@
 
     # Run all the high availability VMs.
     - name: Run highly available VMs
-      include_tasks: tasks/recover/run_vms.yml
+      include_tasks: recover/run_vms.yml
       vars:
           vms: "{{ item }}"
       with_items: "{{ unreg_vms }}"
@@ -190,7 +190,7 @@
 
     # Run all the rest of the VMs.
     - name: Run the rest of the VMs
-      include_tasks: tasks/recover/run_vms.yml
+      include_tasks: recover/run_vms.yml
       vars:
           vms: "{{ item }}"
       with_items: "{{ unreg_vms }}"
@@ -203,7 +203,7 @@
       - fail_back
   always:
      - name: Print operation summary
-       include_tasks: tasks/recover/print_info.yml
+       include_tasks: recover/print_info.yml
      - name: Revoke the SSO token
        ovirt_auth:
            state: absent

--- a/tasks/run_unregistered_entities.yml
+++ b/tasks/run_unregistered_entities.yml
@@ -15,14 +15,14 @@
           state: absent
 
     - name: Run all the high availability VMs
-      include_tasks: tasks/recover/run_vms.yml
+      include_tasks: recover/run_vms.yml
       vars:
           vms: "{{ item }}"
       with_items: "{{ running_vms_fail_back }}"
       when: item.high_availability.enabled | bool
 
     - name: Run all the entire running VMs
-      include_tasks: tasks/recover/run_vms.yml
+      include_tasks: recover/run_vms.yml
       vars:
           vms: "{{ item }}"
       with_items: "{{ running_vms_fail_back }}"


### PR DESCRIPTION
1) Updating "include:" & "include_tasks:" paths to be relative to the location
of the relevant yaml files (vs. relative to the project root).
2) Typo fixed.

Signed-off-by: Pavel Bar <pbar@redhat.com>