### PR TITLE
Ansible 2.9: fixing deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The `oVirt.disaster-recovery` role responsible to manage the disaster recovery s
 Requirements
 ------------
 
- * Ansible version 2.7.2 or higher
- * Python SDK version 4.2.4 or higher
+ * Ansible version 2.9 or higher
+ * Python SDK version 4.4 or higher
 
 Role Variables
 --------------
@@ -17,10 +17,10 @@ Role Variables
 | dr_ignore_error_clean   | False                 | Specify whether to ignore errors on clean engine setup.<br/>This is mainly being used to avoid failures when trying to move a storage domain to maintenance/detach it.      |
 | dr_ignore_error_recover | True                  | Specify whether to ignore errors on recover.      |
 | dr_partial_import       | True                  | Specify whether to use the partial import flag on VM/Template register.<br/>If True, VMs and Templates will be registered without any missing disks, if false VMs/Templates will fail to be registered in case some of their disks will be missing from any of the storage domains.      |
-| dr_target_host          | secondary             | Specify the default target host to be used in the ansible play.<br/> This host indicates the target site which the recover process will bedone.      |
-| dr_source_map           | primary               | Specify the default source map to be used in the play.</br/> The source map indicates the key which is used to get the target value for each attribute which we want to register with the VM/Template.       |
-| dr_reset_mac_pool       | True                  | If true, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
-| dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenace VM as part of a fail back scenario.       |
+| dr_target_host          | secondary             | Specify the default target host to be used in the ansible play.<br/> This host indicates the target site which the recover process will be done.      |
+| dr_source_map           | primary               | Specify the default source map to be used in the play.<br/> The source map indicates the key which is used to get the target value for each attribute which we want to register with the VM/Template.       |
+| dr_reset_mac_pool       | True                  | If True, then once a VM will be registered, it will automatically reset the mac pool, if configured in the VM.        |
+| dr_cleanup_retries_maintenance       | 3                  | Specify the number of retries of moving a storage domain to maintenance VM as part of a fail back scenario.       |
 | dr_cleanup_delay_maintenance       | 120                  | Specify the number of seconds between each retry as part of a fail back scenario.       |
 | dr_clean_orphaned_vms        | True                  | Specify whether to remove any VMs which have no disks from the setup as part of cleanup.       |
 | dr_clean_orphaned_disks        | True                  | Specify whether to remove lun disks from the setup as part of engine setup.       |
@@ -48,34 +48,43 @@ Example Playbook
      - {role: oVirt.disaster-recovery}
 ```
 
-Generate var file mapping [demo](https://youtu.be/s1-Hq_Mk1w8)<br/>
+Generate var file mapping [demo](https://youtu.be/s1-Hq_Mk1w8)
+<br/>
 Fail over scenario [demo](https://youtu.be/mEOgH-Tk09c)
 
 Scripts
 -------
-The ovirt-dr script should provide the user a more convinient way to run
+The ovirt-dr script should provide the user a more convenient way to run
 disaster recovery actions as a way to avoid using ansible playbooks directly.
 There are four actions which the user can execute:
-  validate	validate the var file mapping which is used for failover and failback
-  generate	Generate the mapping var file based on the primary and secondary setup, to be used for failover and failback
-  failover	Start a failover process to the target setup
-  failback	Start a failback process from the target setup to the source setup
+- `generate`	Generate the mapping var file based on the primary and secondary setup, to be used for failover and failback
+- `validate`	Validate the var file mapping which is used for failover and failback
+- `failover`	Start a failover process to the target setup
+- `failback`	Start a failback process from the target setup to the source setup
 
-Each of those actions are using a configuration file which its default location is oVirt.disaster-recovery/files/dr.conf
-The configuration file location can be changed using --conf-file flag in the ovirt-dr script.
-Log file and log level can be configured as well through the ovirt-dr script using the flags --log-file and --log-level
+Each of those actions are using a configuration file whose default location is `oVirt.disaster-recovery/files/dr.conf`<br/>
+The configuration file's location can be changed using `--conf-file` flag in the `ovirt-dr` script.<br/>
+Log file and log level can be configured as well through the `ovirt-dr` script using the flags `--log-file` and `--log-level`
 
 
 Example Script
 --------------
 For mapping file generation:
-  ./ovirt-dr generate --log-file=ovirt-dr.log --log-level=DEBUG
+```console
+$ ./ovirt-dr generate --log-file=ovirt-dr.log --log-level=DEBUG
+```
 For mapping file validation:
-  ./ovirt-dr validate
+```console
+$ ./ovirt-dr validate
+```
 For fail-over operation:
-  ./ovirt-dr failover
+```console
+$ ./ovirt-dr failover
+```
 For fail-back operation:
-  ./ovirt-dr failback
+```console
+$ ./ovirt-dr failback
+```
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Disaster recovery for oVirt engine"
   company: Red Hat, Inc.
   license: Apache License 2.0
-  min_ansible_version: 2.7.2
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:

--- a/ovirt-ansible-disaster-recovery.spec.in
+++ b/ovirt-ansible-disaster-recovery.spec.in
@@ -12,7 +12,7 @@ Group:          Virtualization/Management
 BuildArch:      noarch
 Url:            http://www.ovirt.org
 
-Requires: ansible >= 2.7.2
+Requires: ansible >= 2.9
 
 %description
 This Ansible role provide funtionality to perform disaster recovery for oVirt engine.

--- a/tasks/clean/remove_domain_process.yml
+++ b/tasks/clean/remove_domain_process.yml
@@ -13,15 +13,17 @@
       when: sd.data_centers is not defined
 
     - name: Detached storage domain - Fetch active host for remove
-      ovirt_host_facts:
+      ovirt_host_info:
         pattern: "status=up"
         auth: "{{ ovirt_auth }}"
+      register: host_info
       when: sd.data_centers is not defined
 
     - name: Attached storage domain - Fetch active host for remove
-      ovirt_host_facts:
+      ovirt_host_info:
         pattern: "status=up and storage={{ sd.name }}"
         auth: "{{ ovirt_auth }}"
+      register: host_info
       when: sd.data_centers is defined
 
     # If sp_uuid is still initiated with the default boolean value,
@@ -33,8 +35,8 @@
     - name: Remove storage domain with no force
       include_tasks: remove_domain.yml
       vars:
-          host: "{{ ovirt_hosts[0].id }}"
-      when: "ovirt_hosts is defined and ovirt_hosts|length > 0 and not dr_force"
+          host: "{{ host_info.ovirt_hosts[0].id }}"
+      when: "host_info.ovirt_hosts is defined and host_info.ovirt_hosts|length > 0 and not dr_force"
 
     - name: Force remove storage domain
       include_tasks: remove_domain.yml

--- a/tasks/clean/remove_invalid_filtered_master_domains.yml
+++ b/tasks/clean/remove_invalid_filtered_master_domains.yml
@@ -1,15 +1,16 @@
 - block:
     - name: Fetch invalid storage domain for remove
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
           pattern:  name={{ storage['dr_' + dr_source_map + '_name'] }} and {{ dr_inactive_domain_search }}
           auth: "{{ ovirt_auth }}"
+      register: storage_domain_info
 
     - name: Remove invalid storage domain
       include_tasks: remove_domain_process.yml
       vars:
           sd: "{{ sd }}"
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ storage_domain_info.ovirt_storage_domains }}"
       when: (not only_master and not sd.master) or (only_master and sd.master)
       loop_control:
           loop_var: sd

--- a/tasks/clean/remove_valid_filtered_master_domains.yml
+++ b/tasks/clean/remove_valid_filtered_master_domains.yml
@@ -1,6 +1,6 @@
 - block:
     - name: Fetch active/maintenance/detached storage domain for remove
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
           pattern: >
             name={{ storage['dr_' + dr_source_map + '_name'] }} and
             (
@@ -9,13 +9,14 @@
               {{ dr_unattached_domain_search }}
             )
           auth: "{{ ovirt_auth }}"
+      register: storage_domain_info
 
     - name: Remove valid storage domain
       include_tasks: remove_domain_process.yml
       vars:
           sd: "{{ sd }}"
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ storage_domain_info.ovirt_storage_domains }}"
       when: (not only_master and not sd.master) or (only_master and sd.master)
       loop_control:
           loop_var: sd

--- a/tasks/clean/shutdown_vms.yml
+++ b/tasks/clean/shutdown_vms.yml
@@ -1,19 +1,20 @@
 - block:
     # Get all the running VMs related to a storage domain and shut them down
     - name: Fetch VMs in the storage domain
-      ovirt_vm_facts:
+      ovirt_vm_info:
           pattern: >
             status != down and
             storage.name={{ storage['dr_' + dr_source_map + '_name'] }} and
             datacenter={{ storage['dr_' + dr_source_map + '_dc_name'] }}
           auth: "{{ ovirt_auth }}"
+      register: vm_info
 
     # TODO: Add a wait until the VM is really down
     - name: Shutdown VMs
       include_tasks: shutdown_vm.yml
       vars:
           vms: "{{ item }}"
-      with_items: "{{ ovirt_vms }}"
+      with_items: "{{ vm_info.ovirt_vms }}"
   ignore_errors: "{{ dr_ignore_error_clean }}"
   tags:
       - fail_back

--- a/tasks/clean/update_ovf_store.yml
+++ b/tasks/clean/update_ovf_store.yml
@@ -1,8 +1,9 @@
 - block:
     - name: Fetch storage domain only if active
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
           pattern:  status = active and storage.name={{ storage['dr_' + dr_source_map + '_name'] }}
           auth: "{{ ovirt_auth }}"
+      register: storage_domain_info
 
     - name: Update OVF store for active storage domain
       ovirt_storage_domain:
@@ -10,7 +11,7 @@
           name: "{{ iscsi_storage['dr_' + dr_source_map + '_name'] }}"
           auth: "{{ ovirt_auth }}"
       with_items:
-        - "{{ ovirt_storage_domains }}"
+        - "{{ storage_domain_info.ovirt_storage_domains }}"
   ignore_errors: "{{ dr_ignore_error_clean }}"
   tags:
       - fail_back

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -112,16 +112,17 @@
 
     # Remove direct LUN disks
     - name: Fetch leftover direct LUN disks in the setup
-      ovirt_disk_facts:
+      ovirt_disk_info:
           pattern: disk_type = lun and number_of_vms =0
           auth: "{{ ovirt_auth }}"
+      register: disk_info
       when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
 
     - name: Remove LUN disks if no storage domains left in setup
       include_tasks: clean/remove_disks.yml
       vars:
           disk: "{{ item }}"
-      with_items: "{{ ovirt_disks }}"
+      with_items: "{{ disk_info.ovirt_disks }}"
       when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
 
 

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -90,9 +90,10 @@
           loop_var: storage
 
     - name: Fetch leftover storage domains
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
           pattern: type != glance
           auth: "{{ ovirt_auth }}"
+      register: storage_domain_info
 
     # TODO: Document that behavior
     # Remove VMs only if there are no data storage domains left in the setup
@@ -101,14 +102,14 @@
           pattern: status = down
           auth: "{{ ovirt_auth }}"
       register: vm_info
-      when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
+      when: dr_clean_orphaned_vms and storage_domain_info.ovirt_storage_domains | length == 0
 
     - name: Remove vms if no storage domains left in setup
       include_tasks: clean/remove_vms.yml
       vars:
           vm: "{{ item }}"
       with_items: "{{ vm_info.ovirt_vms }}"
-      when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
+      when: dr_clean_orphaned_vms and storage_domain_info.ovirt_storage_domains | length == 0
 
     # Remove direct LUN disks
     - name: Fetch leftover direct LUN disks in the setup
@@ -116,14 +117,14 @@
           pattern: disk_type = lun and number_of_vms =0
           auth: "{{ ovirt_auth }}"
       register: disk_info
-      when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
+      when: dr_clean_orphaned_disks and storage_domain_info.ovirt_storage_domains | length == 0
 
     - name: Remove LUN disks if no storage domains left in setup
       include_tasks: clean/remove_disks.yml
       vars:
           disk: "{{ item }}"
       with_items: "{{ disk_info.ovirt_disks }}"
-      when: dr_clean_orphaned_disks and ovirt_storage_domains | length == 0
+      when: dr_clean_orphaned_disks and storage_domain_info.ovirt_storage_domains | length == 0
 
 
   # Default value is set in role defaults

--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -97,16 +97,17 @@
     # TODO: Document that behavior
     # Remove VMs only if there are no data storage domains left in the setup
     - name: Fetch leftover VMs in the setup
-      ovirt_vm_facts:
+      ovirt_vm_info:
           pattern: status = down
           auth: "{{ ovirt_auth }}"
+      register: vm_info
       when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
     - name: Remove vms if no storage domains left in setup
       include_tasks: clean/remove_vms.yml
       vars:
           vm: "{{ item }}"
-      with_items: "{{ ovirt_vms }}"
+      with_items: "{{ vm_info.ovirt_vms }}"
       when: dr_clean_orphaned_vms and ovirt_storage_domains | length == 0
 
     # Remove direct LUN disks

--- a/tasks/recover/add_domain.yml
+++ b/tasks/recover/add_domain.yml
@@ -1,12 +1,13 @@
 - block:
     - name: Fetch available hosts in data center
-      ovirt_host_facts:
+      ovirt_host_info:
           pattern: "status=up and datacenter={{ storage['dr_' + dr_target_host + '_dc_name'] }}"
           auth: "{{ ovirt_auth }}"
+      register: host_info
     - block:
       - name: "Check for available hosts"
         fail: msg="No hosts available"
-        when: ovirt_hosts.0 is undefined
+        when: host_info.ovirt_hosts.0 is undefined
     - block:
       - name: Add storage domain if NFS
         include_tasks: add_nfs_domain.yml
@@ -47,7 +48,7 @@
         when: "storage.dr_domain_type == 'fcp'"
         loop_control:
             loop_var: fcp_storage
-      when: ovirt_hosts.0 is defined
+      when: host_info.ovirt_hosts.0 is defined
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:
       - fail_over

--- a/tasks/recover/add_fcp_domain.yml
+++ b/tasks/recover/add_fcp_domain.yml
@@ -9,7 +9,7 @@
           discard_after_delete: "{{ fcp_storage['dr_discard_after_delete'] }}"
           wipe_after_delete: "{{ fcp_storage['dr_wipe_after_delete'] }}"
           backup: "{{ fcp_storage['dr_backup'] }}"
-          host: "{{ ovirt_hosts[0].name }}"
+          host: "{{ host_info.ovirt_hosts[0].name }}"
           auth: "{{ ovirt_auth }}"
           data_center: "{{ fcp_storage['dr_' + dr_target_host + '_dc_name'] }}"
           fcp: {}

--- a/tasks/recover/add_glusterfs_domain.yml
+++ b/tasks/recover/add_glusterfs_domain.yml
@@ -7,7 +7,7 @@
           warning_low_space: "{{ gluster_storage['dr_warning_low_space'] }}"
           wipe_after_delete: "{{ gluster_storage['dr_wipe_after_delete'] }}"
           backup: "{{ gluster_storage['dr_backup'] }}"
-          host: "{{ ovirt_hosts[0].name }}"
+          host: "{{ host_info.ovirt_hosts[0].name }}"
           data_center: "{{ gluster_storage['dr_' + dr_target_host + '_dc_name'] }}"
           auth: "{{ ovirt_auth }}"
           glusterfs:

--- a/tasks/recover/add_iscsi_domain.yml
+++ b/tasks/recover/add_iscsi_domain.yml
@@ -5,7 +5,7 @@
       - name: Login to iSCSI targets
         ovirt_host:
             state: iscsilogin
-            name: "{{ ovirt_hosts[0].name }}"
+            name: "{{ host_info.ovirt_hosts[0].name }}"
             auth: "{{ ovirt_auth }}"
             iscsi:
                 username: "{{ iscsi_storage['dr_' + dr_target_host + '_username']|default('') }}"
@@ -24,7 +24,7 @@
             state: imported
             id: "{{ iscsi_storage['dr_domain_id'] }}"
             name: "{{ iscsi_storage['dr_' + dr_target_host + '_name']|default('') }}"
-            host: "{{ ovirt_hosts[0].name }}"
+            host: "{{ host_info.ovirt_hosts[0].name }}"
             auth: "{{ ovirt_auth }}"
             data_center: "{{ iscsi_storage['dr_' + dr_target_host + '_dc_name'] }}"
             critical_space_action_blocker: "{{ iscsi_storage['dr_critical_space_action_blocker'] }}"

--- a/tasks/recover/add_nfs_domain.yml
+++ b/tasks/recover/add_nfs_domain.yml
@@ -6,7 +6,7 @@
         critical_space_action_blocker: "{{ nfs_storage['dr_critical_space_action_blocker'] }}"
         wipe_after_delete: "{{ nfs_storage['dr_wipe_after_delete'] }}"
         backup: "{{ nfs_storage['dr_backup'] }}"
-        host: "{{ ovirt_hosts[0].name }}"
+        host: "{{ host_info.ovirt_hosts[0].name }}"
         data_center: "{{ nfs_storage['dr_' + dr_target_host + '_dc_name'] }}"
         auth: "{{ ovirt_auth }}"
         nfs:

--- a/tasks/recover/add_posixfs_domain.yml
+++ b/tasks/recover/add_posixfs_domain.yml
@@ -7,7 +7,7 @@
           warning_low_space: "{{ posix_storage['dr_warning_low_space'] }}"
           wipe_after_delete: "{{ posix_storage['dr_wipe_after_delete'] }}"
           backup: "{{ posix_storage['dr_backup'] }}"
-          host: "{{ ovirt_hosts[0].name }}"
+          host: "{{ host_info.ovirt_hosts[0].name }}"
           data_center: "{{ posix_storage['dr_' + dr_target_host + '_dc_name'] }}"
           auth: "{{ ovirt_auth }}"
           posixfs:

--- a/tasks/recover/register_templates.yml
+++ b/tasks/recover/register_templates.yml
@@ -1,17 +1,18 @@
 - block:
     - name: Fetch unregistered Templates from storage domain
-      ovirt_storage_template_facts:
+      ovirt_storage_template_info:
           nested_attributes: "id"
           unregistered: True
           storage_domain: "{{ storage.name }}"
           auth: "{{ ovirt_auth }}"
+      register: storage_template_info
 
     - name: Register template
       include: register_template.yml
-      # The main task already declared ignore errors so that might bredundant to put it here
-      # ignore_errors: "{{ ignore | default(yes) }}"
-      with_items: "{{ ovirt_storage_templates }}"
-      # We use loop_control so storage.name will not be overriden by the nested loop.
+      # The main task is already declared to ignore errors so that might be
+      # redundant to put it here ignore_errors: "{{ ignore | default(yes) }}"
+      with_items: "{{ storage_template_info.ovirt_storage_templates }}"
+      # We use loop_control so storage.name will not be overridden by the nested loop.
       loop_control:
           loop_var: unreg_template
   ignore_errors: "{{ dr_ignore_error_recover }}"

--- a/tasks/recover/register_vms.yml
+++ b/tasks/recover/register_vms.yml
@@ -1,22 +1,22 @@
 - block:
     - name: Fetch unregistered VMs from storage domain
-      ovirt_storage_vm_facts:
+      ovirt_storage_vm_info:
           nested_attributes: "id"
           unregistered: True
           storage_domain: "{{ storage.name }}"
           auth: "{{ ovirt_auth }}"
+      register: storage_vm_info
 
     - name: Set unregistered VMs
       set_fact:
-          unreg_vms: "{{ unreg_vms|default([]) }} + {{ ovirt_storage_vms }}"
+          unreg_vms: "{{ unreg_vms|default([]) }} + {{ storage_vm_info.ovirt_storage_vms }}"
 
-    # TODO: We should filter out vms which were already exists in the setup (diskless VMs)
+    # TODO: We should filter out VMs which already exist in the setup (diskless VMs)
     - name: Register VM
       include: register_vm.yml
-      with_items: "{{ ovirt_storage_vms }}"
-      # We use loop_control so storage.name will not be overriden by the nested loop.
+      with_items: "{{ storage_vm_info.ovirt_storage_vms }}"
+      # We use loop_control so storage.name will not be overridden by the nested loop.
       loop_control:
-
          loop_var: unreg_vm
   ignore_errors: "{{ dr_ignore_error_recover }}"
   tags:

--- a/tasks/recover_engine.yml
+++ b/tasks/recover_engine.yml
@@ -33,8 +33,8 @@
     # TODO: We should add a validation task that will validate whether
     # all the hosts in the other site (primary or secondary) could not be connected
     # and also set a timer that will wait at least 180 seconds until the first
-    # attach will take place. We should do that to prevent sanlock failure with acquire
-    # lockspace. We should use a flag with default true whether to have thise check
+    # attach will take place. We should do that to prevent Sanlock failure with acquire
+    # lockspace. We should use a flag with default true whether to have this check
     # or not.
 
     # TODO: What happens if master is failed to be attached,
@@ -59,9 +59,10 @@
     # Get all the active storage domains in the setup to register
     # all the templates/VMs/Disks
     - name: Fetching active storage domains
-      ovirt_storage_domain_facts:
+      ovirt_storage_domain_info:
           pattern: "status=active"
           auth: "{{ ovirt_auth }}"
+      register: storage_domain_info
 
     - name: Set initial Maps
       set_fact:
@@ -169,16 +170,16 @@
       vars:
           storage: "{{ item }}"
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ storage_domain_info.ovirt_storage_domains }}"
 
-    # Register all the unregistered VMs after we registerd
+    # Register all the unregistered VMs after we registered
     # all the templates from the active storage domains fetched before.
     - name: Register VMs
       include_tasks: recover/register_vms.yml
       vars:
           storage: "{{ item }}"
       with_items:
-          - "{{ ovirt_storage_domains }}"
+          - "{{ storage_domain_info.ovirt_storage_domains }}"
 
     # Run all the high availability VMs.
     - name: Run highly available VMs

--- a/tasks/unregister_entities.yml
+++ b/tasks/unregister_entities.yml
@@ -8,9 +8,10 @@
 
     # Get all the running VMs and shut them down
     - name: Fetch running VMs in the setup
-      ovirt_vm_facts:
+      ovirt_vm_info:
           pattern:  status = up
           auth: "{{ ovirt_auth }}"
+      register: vm_info
 
     - name: Check whether file with running VMs info exists
       stat:
@@ -35,7 +36,7 @@
                   'high_availability': item.high_availability
               }
           ] }}"
-      with_items: "{{ ovirt_vms }}"
+      with_items: "{{ vm_info.ovirt_vms }}"
       when: item.id is defined
 
     - name: Create file to obtain running vms if file does not exist


### PR DESCRIPTION
Fixing deprecation warnings produced by tox & Ansible due to upgrading to Ansible 2.9:
1) ovirt_vm_facts --> ovirt_vm_info
2) ovirt_host_facts -->ovirt_host_info
3) ovirt_disk_facts --> ovirt_disk_info
4) ovirt_storage_vm_facts --> ovirt_storage_vm_info
5) ovirt_storage_template_facts --> ovirt_storage_template_info
6) ovirt_storage_domain_facts --> ovirt_storage_domain_info

Requirements documentation:
1) Updating the requirements to use Ansible 2.9.
2) Other improvements & fixes.

Signed-off-by: Pavel Bar <pbar@redhat.com>