### PR TITLE
warnings: fixing cleanup warnings during failback flow

### DIFF
--- a/tasks/clean_engine.yml
+++ b/tasks/clean_engine.yml
@@ -8,8 +8,6 @@
 
     - name: Shutdown running VMs
       include_tasks: clean/shutdown_vms.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -17,8 +15,6 @@
 
     - name: Update OVF_STORE disk for storage domains
       include_tasks: clean/update_ovf_store.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -41,8 +37,6 @@
 
     - name: Remove non master storage domains with valid statuses
       include_tasks: clean/remove_valid_filtered_master_domains.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -55,8 +49,6 @@
 
     - name: Remove non master storage domains with invalid statuses using force remove
       include_tasks: clean/remove_invalid_filtered_master_domains.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -70,8 +62,6 @@
 
     - name: Remove master storage domains with valid statuses
       include_tasks: clean/remove_valid_filtered_master_domains.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:
@@ -82,8 +72,6 @@
 
     - name: Remove master storage domains with invalid statuses using force remove
       include_tasks: clean/remove_invalid_filtered_master_domains.yml
-      vars:
-          storage: "{{ item }}"
       with_items:
           - "{{ dr_import_storages }}"
       loop_control:


### PR DESCRIPTION
Fixing 6 warnings resulting from "tasks/clean_engine.yml".
The warning:
  [WARNING]: The loop variable 'storage' is already in use. You should set the `loop_var` value in the `loop_control` option for the task to something else to avoid variable collisions and unexpected behavior.

Signed-off-by: Pavel Bar <pbar@redhat.com>