### PR TITLE
python, warnings: Multiple code improvements in "fail_over.py" & "fail_back.py"

### DIFF
--- a/files/fail_back.py
+++ b/files/fail_back.py
@@ -11,7 +11,6 @@ from six.moves import input
 
 from bcolors import bcolors
 
-
 INFO = bcolors.OKGREEN
 INPUT = bcolors.OKGREEN
 WARN = bcolors.WARNING
@@ -22,13 +21,11 @@ PLAY_DEF = "../examples/dr_play.yml"
 report_name = "report-{}.log"
 
 
-class FailBack():
+class FailBack:
 
     def run(self, conf_file, log_file, log_level):
         log = self._set_log(log_file, log_level)
         log.info("Start failback operation...")
-        dr_tag = "fail_back"
-        dr_clean_tag = "clean_engine"
         target_host, source_map, var_file, vault, ansible_play = \
             self._init_vars(conf_file)
         report = report_name.format(int(round(time.time() * 1000)))
@@ -37,7 +34,7 @@ class FailBack():
                  "var_file: %s \n"
                  "vault: %s \n"
                  "ansible_play: %s \n"
-                 "report log: /tmp/%s \n",
+                 "report log file: /tmp/%s\n",
                  target_host,
                  source_map,
                  var_file,
@@ -45,111 +42,90 @@ class FailBack():
                  ansible_play,
                  report)
 
-        cmd = []
-        cmd.append("ansible-playbook")
-        cmd.append(ansible_play)
-        cmd.append("-t")
-        cmd.append(dr_clean_tag)
-        cmd.append("-e")
-        cmd.append("@" + var_file)
-        cmd.append("-e")
-        cmd.append("@" + vault)
-        cmd.append("-e")
-        cmd.append(" dr_source_map=" + target_host)
-        cmd.append("--vault-password-file")
-        cmd.append("vault_secret.sh")
-        cmd.append("-vvv")
+        dr_clean_tag = "clean_engine"
+        extra_vars_cleanup = " dr_source_map=" + target_host
+        command_cleanup = [
+            "ansible-playbook", ansible_play,
+            "-t", dr_clean_tag,
+            "-e", "@" + var_file,
+            "-e", "@" + vault,
+            "-e", extra_vars_cleanup,
+            "--vault-password-file", "vault_secret.sh",
+            "-vvv"
+        ]
 
-        cmd_fb = []
-        cmd_fb.append("ansible-playbook")
-        cmd_fb.append(ansible_play)
-        cmd_fb.append("-t")
-        cmd_fb.append(dr_tag)
-        cmd_fb.append("-e")
-        cmd_fb.append("@" + var_file)
-        cmd_fb.append("-e")
-        cmd_fb.append("@" + vault)
-        cmd_fb.append("-e")
-        cmd_fb.append(" dr_target_host=" + target_host
-                      + " dr_source_map=" + source_map
-                      + " dr_report_file=" + report)
-        cmd_fb.append("--vault-password-file")
-        cmd_fb.append("vault_secret.sh")
-        cmd_fb.append("-vvv")
+        dr_failback_tag = "fail_back"
+        extra_vars_failback = (" dr_target_host=" + target_host
+                               + " dr_source_map=" + source_map
+                               + " dr_report_file=" + report)
+        command_failback = [
+            "ansible-playbook", ansible_play,
+            "-t", dr_failback_tag,
+            "-e", "@" + var_file,
+            "-e", "@" + vault,
+            "-e", extra_vars_failback,
+            "--vault-password-file", "vault_secret.sh",
+            "-vvv"
+        ]
 
-        # Setting vault password
-        vault_pass = input(
-            INPUT + PREFIX + "Please enter vault password (In case of "
-            "plain text please press ENTER): " + END)
+        # Setting vault password.
+        vault_pass_msg = ("Please enter vault password "
+                          "(in case of plain text please press ENTER): ")
+        vault_pass = input(INPUT + PREFIX + vault_pass_msg + END)
         os.system("export vault_password=\"" + vault_pass + "\"")
-        log.info("Starting cleanup process of setup %s"
-                 " for oVirt ansible disaster recovery", target_host)
-        print("\n%s%sStarting cleanup process of setup '%s'"
-              " for oVirt ansible disaster recovery%s"
-              % (INFO,
-                  PREFIX,
-                  target_host,
-                  END))
-        log.info("Executing cleanup command: %s", ' '.join(map(str, cmd)))
+
+        info_msg = ("Starting cleanup process of setup '{}' for "
+                    "oVirt ansible disaster recovery".format(target_host))
+        log.info(info_msg)
+        print("\n%s%s%s%s" % (INFO, PREFIX, info_msg, END))
+
+        log.info("Executing cleanup command: %s",
+                 ' '.join(map(str, command_cleanup)))
         if log_file is not None and log_file != '':
-            self._log_to_file(log_file, cmd)
+            self._log_to_file(log_file, command_cleanup)
         else:
-            self._log_to_console(cmd, log)
+            self._log_to_console(command_cleanup, log)
 
-        log.info("Finished cleanup of setup %s"
-                 " for oVirt ansible disaster recovery", source_map)
-        print("\n%s%sFinished cleanup of setup '%s'"
-              " for oVirt ansible disaster recovery%s"
-              % (INFO,
-                  PREFIX,
-                  source_map,
-                  END))
+        info_msg = ("Finished cleanup of setup '{}' "
+                    "for oVirt ansible disaster recovery".format(source_map))
+        log.info(info_msg)
+        print("\n%s%s%s%s" % (INFO, PREFIX, info_msg, END))
 
-        log.info("Start failback DR from setup '%s'", target_host)
-        print("\n%s%sStarting fail-back process to setup '%s'"
-              " from setup '%s' for oVirt ansible disaster recovery%s"
-              % (INFO,
-                  PREFIX,
-                  target_host,
-                  source_map,
-                  END))
+        info_msg = ("Starting failback process to setup '{}' from setup '{}' "
+                    "for oVirt ansible disaster recovery"
+                    .format(target_host, source_map))
+        log.info(info_msg)
+        print("\n%s%s%s%s" % (INFO, PREFIX, info_msg, END))
 
         log.info("Executing failback command: %s",
-                 ' '.join(map(str, cmd_fb)))
+                 ' '.join(map(str, command_failback)))
         if log_file is not None and log_file != '':
-            self._log_to_file(log_file, cmd_fb)
+            self._log_to_file(log_file, command_failback)
         else:
-            self._log_to_console(cmd_fb, log)
+            self._log_to_console(command_failback, log)
 
         call(["cat", "/tmp/" + report])
         print("\n%s%sFinished failback operation"
-              " for oVirt ansible disaster recovery%s"
-              % (INFO,
-                  PREFIX,
-                  END))
+              " for oVirt ansible disaster recovery%s" % (INFO, PREFIX, END))
 
-    def _log_to_file(self, log_file, cmd):
+    def _log_to_file(self, log_file, command):
         with open(log_file, "a") as f:
-            proc = subprocess.Popen(cmd,
+            proc = subprocess.Popen(command,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
             for line in iter(proc.stdout.readline, ''):
                 if 'TASK [' in line:
-                    print("\n%s%s%s\n" % (INFO,
-                                          line,
-                                          END))
+                    print("\n%s%s%s\n" % (INFO, line, END))
                 if "[Failback Replication Sync]" in line:
                     print("%s%s%s" % (INFO, line, END))
                 f.write(line)
             for line in iter(proc.stderr.readline, ''):
                 f.write(line)
-                print("%s%s%s" % (WARN,
-                                  line,
-                                  END))
+                print("%s%s%s" % (WARN, line, END))
 
-    def _log_to_console(self, cmd, log):
-        proc = subprocess.Popen(cmd,
+    def _log_to_console(self, command, log):
+        proc = subprocess.Popen(command,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
                                 universal_newlines=True)
@@ -160,19 +136,17 @@ class FailBack():
                 log.debug(line)
         for line in iter(proc.stderr.readline, ''):
             log.warn(line)
-        self._handle_result(subprocess, cmd)
+        self._handle_result(command)
 
-    def _handle_result(self, subprocess, cmd):
+    def _handle_result(self, command):
         try:
-            proc = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-            # do something with output
+            # TODO: do something with the returned output?
+            subprocess.check_output(command, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             print("%sException: %s\n\n"
                   "failback operation failed, please check log file for "
                   "further details.%s"
-                  % (FAIL,
-                     e,
-                     END))
+                  % (FAIL, e, END))
             exit()
 
     def _init_vars(self, conf_file):
@@ -185,9 +159,6 @@ class FailBack():
         _ANSIBLE_PLAY = 'ansible_play'
         setups = ['primary', 'secondary']
 
-        """ Declare varialbles """
-        target_host, source_map, vault, var_file, ansible_play = \
-            '', '', '', '', ''
         settings = ConfigParser()
         settings.read(conf_file)
         if _SECTION not in settings.sections():
@@ -202,13 +173,13 @@ class FailBack():
             settings.set(_SECTION, _VAR_FILE, '')
         if not settings.has_option(_SECTION, _ANSIBLE_PLAY):
             settings.set(_SECTION, _ANSIBLE_PLAY, '')
-        # We fetch the source map as target host since in failback
-        # we do the reverse operation.
+        # We fetch the source map as target host,
+        # since in failback we do the reverse operation.
         target_host = settings.get(_SECTION, _SOURCE,
                                    vars=DefaultOption(settings,
                                                       _SECTION,
                                                       source_map=None))
-        # We fetch the target host as target the source mapping for failback
+        # We fetch the target host as target the source mapping for failback,
         # since we do the reverse operation.
         source_map = settings.get(_SECTION, _TARGET,
                                   vars=DefaultOption(settings,
@@ -228,8 +199,8 @@ class FailBack():
                                                        ansible_play=None))
         while target_host not in setups:
             target_host = input(
-                INPUT + PREFIX + "The target setup was not defined. "
-                "Please provide the setup which it is failback to "
+                INPUT + PREFIX + "The target host was not defined. "
+                "Please provide the target host (to failback to) "
                 "(primary or secondary): " + END)
         while source_map not in setups:
             source_map = input(
@@ -241,8 +212,8 @@ class FailBack():
                              "Please provide a valid mapping var file: %s"
                              % (INPUT, PREFIX, var_file, END))
         while not os.path.isfile(vault):
-            vault = input("%s%spassword file '%s' does not exist."
-                          " Please provide a valid password file:%s "
+            vault = input("%s%sPassword file '%s' does not exist. "
+                          "Please provide a valid password file: %s"
                           % (INPUT, PREFIX, vault, END))
         while (not ansible_play) or (not os.path.isfile(ansible_play)):
             ansible_play = input("%s%sansible play '%s' "
@@ -256,15 +227,16 @@ class FailBack():
 
     def _set_log(self, log_file, log_level):
         logger = logging.getLogger(PREFIX)
-        formatter = logging.Formatter(
-            '%(asctime)s %(levelname)s %(message)s')
+
         if log_file is not None and log_file != '':
+            formatter = logging.Formatter(
+                '%(asctime)s %(levelname)s %(message)s')
             hdlr = logging.FileHandler(log_file)
             hdlr.setFormatter(formatter)
-            logger.addHandler(hdlr)
         else:
-            ch = logging.StreamHandler(sys.stdout)
-            logger.addHandler(ch)
+            hdlr = logging.StreamHandler(sys.stdout)
+
+        logger.addHandler(hdlr)
         logger.setLevel(log_level)
         return logger
 
@@ -288,7 +260,6 @@ class DefaultOption(dict):
 
 
 if __name__ == "__main__":
-    level = logging.getLevelName("DEBUG")
-    conf = 'dr.conf'
-    log = '/tmp/ovirt-dr.log'
-    FailBack().run(conf, log, level)
+    FailBack().run(conf_file='dr.conf',
+                   log_file='/tmp/ovirt-dr.log',
+                   log_level=logging.getLevelName("DEBUG"))


### PR DESCRIPTION
- Fixing code warnings.
- Local variables' renaming to improve readability, fixing confusing/bad names.
- Different code reorganizations to improve readability.
- Updating "enter vault password" to make failover to be consistent with failback flow.
- Fixing log message that prints a wrong setup (target instead of source):
  "Starting failback DR from setup XXX"
- Adding "TODO"s to be handled later.

Signed-off-by: Pavel Bar <pbar@redhat.com>