### PR TITLE
pre-collections: small issues fixed

### DIFF
--- a/files/generate_vars.py
+++ b/files/generate_vars.py
@@ -21,7 +21,6 @@ PREFIX = "[Generate Mapping File] "
 CA_DEF = '/etc/pki/ovirt-engine/ca.pem'
 USERNAME_DEF = 'admin@internal'
 SITE_DEF = 'http://localhost:8080/ovirt-engine/api'
-VAR_DEF = "/var/lib/ovirt-ansible-disaster-recovery/mapping_vars.yml"
 PLAY_DEF = "../examples/dr_play.yml"
 
 

--- a/files/validator.py
+++ b/files/validator.py
@@ -123,12 +123,10 @@ class ValidateMappingFile:
 
         # If no default location exists, get the location from the user.
         while not var_file:
-            var_file = input("%s%sVar file is not initialized. "
-                             "Please provide the location of the var file "
-                             "(%s):%s " % (WARN,
-                                           PREFIX,
-                                           self.def_var_file,
-                                           END) or self.def_var_file)
+            var_file = input("%s%sVar file is not initialized. Please provide "
+                             "the location of the var file (%s):%s " %
+                             (WARN, PREFIX, self.def_var_file, END)
+                             ) or self.def_var_file
 
         self.var_file = var_file
 

--- a/files/validator.py
+++ b/files/validator.py
@@ -37,8 +37,7 @@ class ValidateMappingFile:
               "for oVirt ansible disaster recovery%s"
               % (INFO, PREFIX, END))
         self._set_dr_conf_variables(conf_file)
-        print("%s%sVar File: '%s'%s"
-              % (INFO, PREFIX, self.var_file, END))
+        print("%s%sVar File: '%s'%s" % (INFO, PREFIX, self.var_file, END))
         while not os.path.isfile(self.var_file):
             self.var_file = input(
                 "%s%sVar file '%s' does not exists. "
@@ -82,11 +81,7 @@ class ValidateMappingFile:
         if not isinstance(map_file, list) and map_file is not None:
             print("%s%s%s is not a list: '%s'."
                   " Please check your mapping file%s"
-                  % (FAIL,
-                     PREFIX,
-                     mapping,
-                     map_file,
-                     END))
+                  % (FAIL, PREFIX, mapping, map_file, END))
             return False
         return True
 
@@ -172,7 +167,7 @@ class ValidateMappingFile:
                     second_conn,
                     cluster_mapping)
             finally:
-                # Close the connections
+                # Close the connections.
                 if primary_conn:
                     primary_conn.close()
                 if second_conn:
@@ -233,7 +228,7 @@ class ValidateMappingFile:
                     self._fetch_affinity_groups(cluster_service))
         aff_labels = self._get_affinity_labels(conn)
         aaa_domains = self._get_aaa_domains(conn)
-        # TODO: Remove once vnic prifle is validated.
+        # TODO: Remove once vnic profile is validated.
         networks = self._get_vnic_profile_mapping(conn)
         isValid = self._validate_networks(
             python_vars,
@@ -365,7 +360,7 @@ class ValidateMappingFile:
         for x in _mapping:
             if key_setup not in x.keys():
                 print(
-                    "%s%sdictionary key '%s' is not include in %s[%s].%s" %
+                    "%s%sdictionary key '%s' is not included in %s[%s].%s" %
                     (FAIL,
                      PREFIX,
                      key_setup,
@@ -391,11 +386,7 @@ class ValidateMappingFile:
             print(
                 "%s%sFinished validation for '%s' for key name "
                 "'%s' with success.%s" %
-                (INFO,
-                 PREFIX,
-                 key,
-                 key_setup,
-                 END))
+                (INFO, PREFIX, key, key_setup, END))
         return isValid
 
     def _validate_hosted_engine(self, var_file):
@@ -425,24 +416,25 @@ class ValidateMappingFile:
         clusters = 'clusters'
         domains = 'domains'
         roles = 'roles'
-        aff_group = 'aff_groups'
-        aff_label = 'aff_labels'
+        aff_groups = 'aff_groups'
+        aff_labels = 'aff_labels'
         network = 'network'
         key1 = 'primary_name'
         key2 = 'secondary_name'
+        dr_primary_name = 'dr_primary_name'
+        dr_secondary_name = 'dr_secondary_name'
 
         duplicates = self._get_dups(
             var_file, [
                 [clusters, self.cluster_map, key1, key2],
-                [domains, self.domain_map, 'dr_primary_name',
-                 'dr_secondary_name'],
+                [domains, self.domain_map, dr_primary_name, dr_secondary_name],
                 [roles, self.role_map, key1, key2],
-                [aff_group, self.aff_group_map, key1, key2],
-                [aff_label, self.aff_label_map, key1, key2]])
+                [aff_groups, self.aff_group_map, key1, key2],
+                [aff_labels, self.aff_label_map, key1, key2]])
         duplicates[network] = self._get_dup_network(var_file)
         isValid = (not self._print_duplicate_keys(
-            duplicates, [clusters, domains, roles, aff_group,
-                         aff_label, network])) and isValid
+            duplicates, [clusters, domains, roles, aff_groups,
+                         aff_labels, network])) and isValid
         return isValid
 
     def _validate_vms_for_failback(self, setup_conn, setup_type):
@@ -461,21 +453,13 @@ class ValidateMappingFile:
             print("%s%sFailback process does not support VMs in preview."
                   " The '%s' setup contains the following previewed vms:"
                   " '%s'%s"
-                  % (FAIL,
-                     PREFIX,
-                     setup_type,
-                     vms_in_preview,
-                     END))
+                  % (FAIL, PREFIX, setup_type, vms_in_preview, END))
             return False
         if len(vms_delete_protected) > 0:
             print("%s%sFailback process does not support delete protected"
                   " VMs. The '%s' setup contains the following vms:"
                   " '%s'%s"
-                  % (FAIL,
-                     PREFIX,
-                     setup_type,
-                     vms_delete_protected,
-                     END))
+                  % (FAIL, PREFIX, setup_type, vms_delete_protected, END))
             return False
         return True
 

--- a/files/validator.py
+++ b/files/validator.py
@@ -135,12 +135,11 @@ class ValidateMappingFile:
         return ret_val
 
     def _entity_validator(self, python_vars):
-        isValid = True
         ovirt_setups = ConnectSDK(
             python_vars,
             self.primary_pwd,
             self.second_pwd)
-        isValid = ovirt_setups.validate_primary() and isValid
+        isValid = ovirt_setups.validate_primary()
         isValid = ovirt_setups.validate_secondary() and isValid
         if isValid:
             primary_conn, second_conn = '', ''
@@ -212,7 +211,6 @@ class ValidateMappingFile:
         return True
 
     def _validate_entities_in_setup(self, conn, setup, python_vars):
-        isValid = True
         dcs_service = conn.system_service().data_centers_service()
         dcs_list = dcs_service.list()
         clusters = []
@@ -233,7 +231,7 @@ class ValidateMappingFile:
         isValid = self._validate_networks(
             python_vars,
             networks,
-            setup) and isValid
+            setup)
         isValid = self._validate_entity_exists(
             clusters,
             python_vars,
@@ -412,7 +410,6 @@ class ValidateMappingFile:
         return True
 
     def _validate_duplicate_keys(self, var_file):
-        isValid = True
         clusters = 'clusters'
         domains = 'domains'
         roles = 'roles'
@@ -432,10 +429,9 @@ class ValidateMappingFile:
                 [aff_groups, self.aff_group_map, key1, key2],
                 [aff_labels, self.aff_label_map, key1, key2]])
         duplicates[network] = self._get_dup_network(var_file)
-        isValid = (not self._print_duplicate_keys(
-            duplicates, [clusters, domains, roles, aff_groups,
-                         aff_labels, network])) and isValid
-        return isValid
+        return not self._print_duplicate_keys(
+            duplicates,
+            [clusters, domains, roles, aff_groups, aff_labels, network])
 
     def _validate_vms_for_failback(self, setup_conn, setup_type):
         vms_in_preview = []


### PR DESCRIPTION
Solving a few issues to enhance moving to collections:

1. Removing unused path variable in "generate_vars.py" containing the "disaster-recovery" substring (that otherwise should have been changed in the collections project).
2. Fixing a bug with user input in "validator.py".
3. A few improvements in "validator.py"

Signed-off-by: Pavel Bar <pbar@redhat.com>